### PR TITLE
Minor fixes for timestamp edits

### DIFF
--- a/backend/app/models/chapter_operation.py
+++ b/backend/app/models/chapter_operation.py
@@ -147,7 +147,7 @@ class EditTimestampOperation(ChapterOperation):
 
         self.old_timestamp = chapter.timestamp
         chapter.timestamp = self.new_timestamp
-        
+
         self.old_realignment = chapter.realignment
         if chapter.realignment:
             new_realignment = RealignmentData(
@@ -157,7 +157,11 @@ class EditTimestampOperation(ChapterOperation):
             )
             chapter.realignment = new_realignment
 
+        pipeline.chapters.sort(key=lambda c: c.timestamp)
+
     def undo(self, pipeline: "ProcessingPipeline"):
         chapter = self.find_chapter(pipeline, self.chapter_id)
         chapter.timestamp = self.old_timestamp
         chapter.realignment = self.old_realignment
+
+        pipeline.chapters.sort(key=lambda c: c.timestamp)

--- a/docs/editor/overview.md
+++ b/docs/editor/overview.md
@@ -17,7 +17,7 @@ The editor shows a list of chapters and an Action Bar at the bottom.
 | # | Component | What it does |
 |--:|---|---|
 | 1 | :material-checkbox-marked:{ .icon-token .primary } Checkbox | Selects or deselects the chapter. <kbd>Shift</kbd>-click another checkbox to apply the same selection state to every chapter in the range between the two clicks. The checkbox at the very top can be used to select/deselect all chapters. |
-| 2 | Timestamp | The chapter timestamp. Clicking on the timestamp allows you to edit it. Toggle between formatted timestamps and raw seconds in the [editor settings](#editor-settings). |
+| 2 | Timestamp | The chapter timestamp. Clicking on the timestamp allows you to edit it. The very first chapter (timestamp `0`) is fixed and cannot be edited. Toggle between formatted timestamps and raw seconds in the [editor settings](#editor-settings). |
 | 3 | Offset | Shown when using the [Realignment](../workflows/realign-chapters.md) workflow. Shows the difference between the original source timestamp and the realigned one. A warning icon :lucide-triangle-alert:{ .icon-token .warning } appears on low-confidence or guessed alignments; give those a listen to verify accuracy before submitting your chapters. |
 | 4 | Transcription | The raw transcription for the chapter. Non-editable, serves as a reference for writing the title. The transcription column can be hidden via the [editor settings](#editor-settings). |
 | 5 | :lucide-arrow-right:{ .icon-token .primary } Use Transcription | Replaces the current title with the transcribed text. Disabled when there is no transcription, or when the title already matches the transcription. |

--- a/docs/editor/shift-timestamps.md
+++ b/docs/editor/shift-timestamps.md
@@ -13,6 +13,8 @@ Choose which chapters get shifted:
 - **All chapters:** Every chapter in the chapter editor.
 - **Between first and last selected:** Every chapter (including unselected ones) between the first and last selected chapters in the editor. Only available when at least two chapters are selected.
 
+Regardless of which mode you choose, the very first chapter (timestamp `0`) is fixed and never shifted.
+
 ## Offset
 
 The amount to shift, in seconds. Positive values shift later, negative values shift earlier.
@@ -54,6 +56,6 @@ Controls how the offset drift is interpolated:
 
 The dialog lists every affected chapter, showing both old and new timestamps. Changed timestamps are highlighted, and a counter at the top shows how many chapters will actually move. Click the :lucide-play:{ .icon-token .primary } play button on any row to hear the audio at that chapter's new position.
 
-Timestamps are clamped to the book's duration, so a shift that would push a chapter past the end (or before zero) is capped rather than rejected.
+Timestamps are clamped between `0:01` and the book's duration. Shifted chapters are also spaced at least 1 second apart to avoid collapsing onto the same timestamp.
 
 Click **Apply** to perform the shift. Like any editor action, it's recoverable via [Undo](undo-redo.md).

--- a/frontend/src/components/ChapterEditor.svelte
+++ b/frontend/src/components/ChapterEditor.svelte
@@ -697,7 +697,7 @@
         const prevChapter = currentChapterIndex > 0 ? $chapters[currentChapterIndex - 1] : null;
         const nextChapter = currentChapterIndex < $chapters.length - 1 ? $chapters[currentChapterIndex + 1] : null;
 
-        const minTimestamp = prevChapter ? prevChapter.timestamp + 1 : 0;
+        const minTimestamp = prevChapter ? prevChapter.timestamp + 1 : 1;
         const maxTimestamp = nextChapter ? nextChapter.timestamp - 1 : $session.book?.duration - 1 || Infinity;
 
         if (timestamp < minTimestamp) {
@@ -955,7 +955,7 @@
                                         <X size="14"/>
                                     </button>
                                 </div>
-                            {:else}
+                            {:else if chapter.timestamp > 0.01}
                                 <button
                                     class="timestamp-display"
                                     onclick={() => startTimestampEdit(chapter.id, chapter.timestamp)}
@@ -963,6 +963,13 @@
                                 >
                                     {formatTimestamp(chapter.timestamp)}
                                 </button>
+                            {:else}
+                                <span
+                                    class="timestamp-display readonly"
+                                    title="The first chapter must start at 0"
+                                >
+                                    {formatTimestamp(chapter.timestamp)}
+                                </span>
                             {/if}
                         </td>
                         {#if hasAlignmentData}
@@ -1557,12 +1564,16 @@
         transition: all 0.2s ease;
     }
 
-    .timestamp-display:hover {
+    .timestamp-display:hover:not(.readonly) {
         color: var(--text-primary);
         background-color: var(--hover-bg);
         border-radius: 0.25rem;
         padding: 0.25rem;
         margin: -0.25rem;
+    }
+
+    .timestamp-display.readonly {
+        cursor: default;
     }
 
 

--- a/frontend/src/components/ShiftTimestampsDialog.svelte
+++ b/frontend/src/components/ShiftTimestampsDialog.svelte
@@ -36,15 +36,16 @@
 
     let showBetweenOption = $derived(selectedChapters.length >= 2);
 
+    // The first chapter is always pinned to 0 and cannot be shifted.
     let affectedChapters = $derived.by(() => {
-        const nonDeleted = $chapters.filter(ch => !ch.deleted);
-        if (applyTo === "selected") return nonDeleted.filter(ch => ch.selected);
-        if (applyTo === "all") return nonDeleted;
+        const shiftable = $chapters.filter(ch => !ch.deleted && ch.timestamp > 0.01);
+        if (applyTo === "selected") return shiftable.filter(ch => ch.selected);
+        if (applyTo === "all") return shiftable;
         // "between": all non-deleted chapters between first and last selected timestamps
-        if (selectedChapters.length < 2) return selectedChapters;
+        if (selectedChapters.length < 2) return shiftable.filter(ch => ch.selected);
         const minTs = Math.min(...selectedChapters.map(ch => ch.timestamp));
         const maxTs = Math.max(...selectedChapters.map(ch => ch.timestamp));
-        return nonDeleted.filter(ch => ch.timestamp >= minTs && ch.timestamp <= maxTs);
+        return shiftable.filter(ch => ch.timestamp >= minTs && ch.timestamp <= maxTs);
     });
 
     let showDriftOption = $derived(affectedChapters.length >= 3);
@@ -63,7 +64,9 @@
     );
 
     function computeNewTimestamps() {
-        return affectedChapters.map((ch, i) => {
+        const result = [];
+        let prevTs = 0; // Reflects fixed first chapter at 0:00
+        affectedChapters.forEach((ch, i) => {
             let newTs;
             if (driftEnabled && affectedChapters.length >= 2) {
                 let t;
@@ -79,11 +82,12 @@
             } else {
                 newTs = ch.timestamp + offset;
             }
-            return {
-                chapter_id: ch.id,
-                new_timestamp: Math.max(0, Math.min(bookDuration - 1, newTs)),
-            };
+            newTs = Math.max(0, Math.min(bookDuration - 1, newTs));
+            newTs = Math.min(bookDuration - 1, Math.max(newTs, prevTs + 1));
+            result.push({chapter_id: ch.id, new_timestamp: newTs});
+            prevTs = newTs;
         });
+        return result;
     }
 
     let previewData = $derived.by(() => {


### PR DESCRIPTION
- Disallow editing first chapter timestamp
- Clamp timestamps edits to 0:01
- Ensure chapters are sorted after edit
- Enforce 1s minimum chapter duration in ShiftTimestampsDialog
- Update docs