### PR TITLE
fix: handle non-UTF-8 bytes in ffmpeg probe output

### DIFF
--- a/backend/app/services/audio_service.py
+++ b/backend/app/services/audio_service.py
@@ -52,7 +52,8 @@ def _ffmpeg_probe_stderr(audio_file: str) -> str:
     try:
         result = subprocess.run(
             ["ffmpeg", "-hide_banner", "-i", audio_file],
-            capture_output=True, text=True, timeout=30,
+            capture_output=True, timeout=30,
+            encoding="utf-8", errors="replace",
         )
         return result.stderr
     except (subprocess.TimeoutExpired, FileNotFoundError, OSError) as e:


### PR DESCRIPTION
Use `errors='replace'` instead of `text=True` in `subprocess.run` to avoid `UnicodeDecodeError` when audiobook metadata contains non-UTF-8 characters.

<img width="799" height="187" alt="Screenshot 2026-05-07 at 23 13 24" src="https://github.com/user-attachments/assets/8a16a4be-32dd-4853-b5ae-0064ff7e411e" />

<br />

<img width="1116" height="310" alt="Screenshot 2026-05-07 at 23 04 51" src="https://github.com/user-attachments/assets/8baeda7b-22e9-4877-98fc-849ce537ab2d" />

<br />

<details>
<summary>logs</summary>

```
2026-05-07 23:13:19,791 - app.app - INFO - Broadcasting step change to downloading
2026-05-07 23:13:27,782 - app.services.processing_pipeline - ERROR - Fetching item failed: 'utf-8' codec can't decode byte 0xc3 in position 837: invalid continuation byte
Traceback (most recent call last):
  File "/Users/danilo/code/opensource/achew/backend/app/services/processing_pipeline.py", line 827, in fetch_item
    if self.audio_file_path and audio_uses_xhe_aac(self.audio_file_path):
                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/danilo/code/opensource/achew/backend/app/services/audio_service.py", line 65, in audio_uses_xhe_aac
    return "xhe-aac" in _ffmpeg_probe_stderr(audio_file).lower()
                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/danilo/code/opensource/achew/backend/app/services/audio_service.py", line 53, in _ffmpeg_probe_stderr
    result = subprocess.run(
             ^^^^^^^^^^^^^^^
  File "/Users/danilo/.local/share/uv/python/cpython-3.12.8-macos-aarch64-none/lib/python3.12/subprocess.py", line 550, in run
    stdout, stderr = process.communicate(input, timeout=timeout)
                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/danilo/.local/share/uv/python/cpython-3.12.8-macos-aarch64-none/lib/python3.12/subprocess.py", line 1209, in communicate
    stdout, stderr = self._communicate(input, endtime, timeout)
                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/danilo/.local/share/uv/python/cpython-3.12.8-macos-aarch64-none/lib/python3.12/subprocess.py", line 2157, in _communicate
    stderr = self._translate_newlines(stderr,
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/danilo/.local/share/uv/python/cpython-3.12.8-macos-aarch64-none/lib/python3.12/subprocess.py", line 1086, in _translate_newlines
    data = data.decode(encoding, errors)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
UnicodeDecodeError: 'utf-8' codec can't decode byte 0xc3 in position 837: invalid continuation byte
2026-05-07 23:13:27,784 - app.services.processing_pipeline - INFO - Restarting pipeline at step: RestartStep.IDLE
2026-05-07 23:13:27,784 - app.services.processing_pipeline - INFO - Cancelling processing pipeline…
2026-05-07 23:13:27,792 - app.services.processing_pipeline - INFO - Removed temp directory: /var/folders/91/x69q0_x14jl3_xm7tmw599yw0000gp/T/achew/8edf5a22-051c-4426-bdce-31eafac8ee9dioc5855j
2026-05-07 23:13:27,792 - app.app - INFO - Deleted pipeline
2026-05-07 23:13:27,792 - app.api.routes.pipeline - ERROR - Fetching item failed: 'utf-8' codec can't decode byte 0xc3 in position 837: invalid continuation byte
Traceback (most recent call last):
  File "/Users/danilo/code/opensource/achew/backend/app/api/routes/pipeline.py", line 80, in start_processing
    result = await pipeline.fetch_item(request.item_id)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/danilo/code/opensource/achew/backend/app/services/processing_pipeline.py", line 827, in fetch_item
    if self.audio_file_path and audio_uses_xhe_aac(self.audio_file_path):
                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/danilo/code/opensource/achew/backend/app/services/audio_service.py", line 65, in audio_uses_xhe_aac
    return "xhe-aac" in _ffmpeg_probe_stderr(audio_file).lower()
                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/danilo/code/opensource/achew/backend/app/services/audio_service.py", line 53, in _ffmpeg_probe_stderr
    result = subprocess.run(
             ^^^^^^^^^^^^^^^
  File "/Users/danilo/.local/share/uv/python/cpython-3.12.8-macos-aarch64-none/lib/python3.12/subprocess.py", line 550, in run
    stdout, stderr = process.communicate(input, timeout=timeout)
                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/danilo/.local/share/uv/python/cpython-3.12.8-macos-aarch64-none/lib/python3.12/subprocess.py", line 1209, in communicate
    stdout, stderr = self._communicate(input, endtime, timeout)
                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/danilo/.local/share/uv/python/cpython-3.12.8-macos-aarch64-none/lib/python3.12/subprocess.py", line 2157, in _communicate
    stderr = self._translate_newlines(stderr,
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/danilo/.local/share/uv/python/cpython-3.12.8-macos-aarch64-none/lib/python3.12/subprocess.py", line 1086, in _translate_newlines
    data = data.decode(encoding, errors)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
UnicodeDecodeError: 'utf-8' codec can't decode byte 0xc3 in position 837: invalid continuation byte
2026-05-07 23:13:27,793 - app.app - INFO - Broadcasting step change to idle
```
</details>
