### PR TITLE
Fix OOM during silence detection on MP3s with embedded cover art

### DIFF
--- a/backend/app/services/audio_service.py
+++ b/backend/app/services/audio_service.py
@@ -1,5 +1,4 @@
 import asyncio
-import collections
 import functools
 import logging
 import os
@@ -391,7 +390,7 @@ class AudioProcessingService:
         publish_progress: bool = True,
     ) -> Optional[List[Tuple[float, float]]]:
         """Run silence detection in a separate thread"""
-        process = subprocess.Popen(cmd, stderr=subprocess.PIPE, stdout=subprocess.DEVNULL, text=True, encoding="utf-8", errors="replace")
+        process = subprocess.Popen(cmd, stderr=subprocess.PIPE, text=True, encoding="utf-8", errors="replace")
 
         with self._process_lock:
             self._running_processes.append(process)
@@ -491,12 +490,10 @@ class AudioProcessingService:
             "null",
             "-progress",
             "pipe:2",
-            "-stats_period",
-            "1",
             "-",
         ]
 
-        process = subprocess.Popen(cmd, stderr=subprocess.PIPE, stdout=subprocess.DEVNULL, text=True, encoding="utf-8", errors="replace")
+        process = subprocess.Popen(cmd, stderr=subprocess.PIPE, text=True, encoding="utf-8", errors="replace")
 
         with self._process_lock:
             self._running_processes.append(process)
@@ -1510,12 +1507,12 @@ class AudioProcessingService:
                 output_file,
             ]
             process = subprocess.Popen(
-                cmd, stderr=subprocess.PIPE, stdout=subprocess.DEVNULL, text=True, encoding="utf-8", errors="replace"
+                cmd, stderr=subprocess.PIPE, stdout=subprocess.PIPE, text=True, encoding="utf-8", errors="replace"
             )
             with self._process_lock:
                 self._running_processes.append(process)
 
-            stderr_output = collections.deque(maxlen=100)
+            stderr_output = []
 
             # Parse progress output in real-time
             current_time = 0.0

--- a/backend/app/services/audio_service.py
+++ b/backend/app/services/audio_service.py
@@ -1,4 +1,5 @@
 import asyncio
+import collections
 import functools
 import logging
 import os
@@ -357,6 +358,7 @@ class AudioProcessingService:
                 "ffmpeg",
                 "-i",
                 input_file,
+                "-vn",
                 "-af",
                 f"silencedetect=n={silence_threshold}dB:d={MIN_SILENCE_DURATION}",
                 "-f",
@@ -389,7 +391,7 @@ class AudioProcessingService:
         publish_progress: bool = True,
     ) -> Optional[List[Tuple[float, float]]]:
         """Run silence detection in a separate thread"""
-        process = subprocess.Popen(cmd, stderr=subprocess.PIPE, text=True, encoding="utf-8", errors="replace")
+        process = subprocess.Popen(cmd, stderr=subprocess.PIPE, stdout=subprocess.DEVNULL, text=True, encoding="utf-8", errors="replace")
 
         with self._process_lock:
             self._running_processes.append(process)
@@ -482,16 +484,19 @@ class AudioProcessingService:
             input_file,
             "-t",
             str(segment_duration),
+            "-vn",
             "-af",
             f"silencedetect=n={silence_threshold}dB:d={MIN_SILENCE_DURATION}",
             "-f",
             "null",
             "-progress",
             "pipe:2",
+            "-stats_period",
+            "1",
             "-",
         ]
 
-        process = subprocess.Popen(cmd, stderr=subprocess.PIPE, text=True, encoding="utf-8", errors="replace")
+        process = subprocess.Popen(cmd, stderr=subprocess.PIPE, stdout=subprocess.DEVNULL, text=True, encoding="utf-8", errors="replace")
 
         with self._process_lock:
             self._running_processes.append(process)
@@ -1505,12 +1510,12 @@ class AudioProcessingService:
                 output_file,
             ]
             process = subprocess.Popen(
-                cmd, stderr=subprocess.PIPE, stdout=subprocess.PIPE, text=True, encoding="utf-8", errors="replace"
+                cmd, stderr=subprocess.PIPE, stdout=subprocess.DEVNULL, text=True, encoding="utf-8", errors="replace"
             )
             with self._process_lock:
                 self._running_processes.append(process)
 
-            stderr_output = []
+            stderr_output = collections.deque(maxlen=100)
 
             # Parse progress output in real-time
             current_time = 0.0


### PR DESCRIPTION
(Authored by claude, reviewed and tested by me. Container was bringing down a whole Ubuntu VM when doing silence detection on an mp3. Issue seems to be that when doing silence detection on an mp3 with embedded "video stream" such as cover art, something causes ffmpeg to use way too much memory. Claude's analysis below)

Add -vn to ffmpeg silence detection commands so the embedded MJPEG video stream (e.g. cover art) is ignored. Without it, ffmpeg buffers the entire decoded audio segment waiting for A/V sync against the static single-frame video stream, consuming several GB on long files.

Also add -stats_period 1 to parallel workers to cut per-frame progress output from ~15M lines to ~60K for a 16-hour book, redirect all silence detection stdout to DEVNULL (-f null output is empty anyway), and fix an unbounded stderr list accumulation in concat_files (deque(maxlen=100)).

Tested against a 16-hour MP3 (Chapterhouse Dune): peak RSS 186 MiB, 4298 cues detected in 86s with 2 parallel workers. Previously OOM-killed.