### PR TITLE
Add generic OpenAI-compatible LLM provider

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,10 @@
 backend/app/config/
 frontend/dist/
 
+# Runtime data from docker-compose / container runs (mounted at repo root)
+/config/
+/cache/
+
 # Generated for Docker build (not committed)
 THIRD_PARTY_NOTICES.txt
 frontend-notices.txt

--- a/backend/app/api/routes/config.py
+++ b/backend/app/api/routes/config.py
@@ -540,6 +540,13 @@ async def get_llm_provider_models(provider_id: str):
             provider_config = {"host": config.llm.ollama.host or "http://localhost:11434"}
         elif provider_id == "lm_studio":
             provider_config = {"host": config.llm.lm_studio.host or "http://localhost:1234"}
+        elif provider_id == "openai_compatible":
+            if not config.llm.openai_compatible.base_url:
+                raise HTTPException(status_code=400, detail="OpenAI-compatible provider not configured")
+            provider_config = {
+                "base_url": config.llm.openai_compatible.base_url,
+                "api_key": config.llm.openai_compatible.api_key,
+            }
 
         models = await get_provider_models(provider_id, **provider_config)
         return LLMModelsResponse(models=models)
@@ -656,6 +663,9 @@ async def cancel_llm_provider_changes(provider_id: str):
         elif provider_id == "lm_studio":
             config.llm.lm_studio.config_changed = False
             save_llm_provider_config("lm_studio", config.llm.lm_studio)
+        elif provider_id == "openai_compatible":
+            config.llm.openai_compatible.config_changed = False
+            save_llm_provider_config("openai_compatible", config.llm.openai_compatible)
 
         # Refresh global config cache
         refresh_app_config()

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -29,6 +29,7 @@ class LLMProviderConfig(BaseModel):
 
     api_key: str = ""
     host: str = ""  # For providers like Ollama
+    base_url: str = ""  # For OpenAI-compatible endpoints (e.g. LiteLLM)
     validated: bool = False
     last_validated: Optional[datetime] = None
     enabled: bool = False  # Default to disabled
@@ -47,6 +48,7 @@ class LLMConfig(BaseModel):
     openrouter: LLMProviderConfig = LLMProviderConfig()
     ollama: LLMProviderConfig = LLMProviderConfig()
     lm_studio: LLMProviderConfig = LLMProviderConfig()
+    openai_compatible: LLMProviderConfig = LLMProviderConfig()
 
     # AI cleanup preferences
     last_used_provider: str = ""

--- a/backend/app/services/llm_providers/__init__.py
+++ b/backend/app/services/llm_providers/__init__.py
@@ -1,6 +1,7 @@
 from .base import AIService, ModelInfo, ProviderInfo
 from .copilot_service import CopilotService
 from .ollama_service import OllamaService
+from .openai_compatible_service import OpenAICompatibleService
 from .openai_service import OpenAIService
 from .openrouter_service import OpenRouterService
 from .registry import create_provider, get_all_providers, get_registry, register_provider
@@ -12,6 +13,7 @@ __all__ = [
     "OpenAIService",
     "OllamaService",
     "OpenRouterService",
+    "OpenAICompatibleService",
     "CopilotService",
     "get_registry",
     "register_provider",

--- a/backend/app/services/llm_providers/openai_compatible_service.py
+++ b/backend/app/services/llm_providers/openai_compatible_service.py
@@ -1,0 +1,457 @@
+import json
+import logging
+from typing import List, Optional
+
+import httpx
+
+from app.models.abs import Book
+
+from .base import AIService, IncrementalJSONParser, ModelInfo, ProviderInfo
+
+logger = logging.getLogger(__name__)
+
+
+class OpenAICompatibleService(AIService):
+    """Generic provider for any OpenAI-compatible endpoint (e.g. LiteLLM, vLLM).
+
+    Talks the standard OpenAI REST surface: ``GET {base_url}/models`` for
+    discovery and ``POST {base_url}/chat/completions`` for generation. The base
+    URL and (optional) API key are supplied by the user via the frontend.
+    """
+
+    def __init__(self, progress_callback, **config):
+        super().__init__(progress_callback, **config)
+
+    def _get_base_url(self, config=None) -> Optional[str]:
+        """Get the current base URL from config or saved configuration."""
+        if config and config.get("base_url"):
+            base_url = config["base_url"]
+        else:
+            from ...core.config import get_app_config
+
+            app_config = get_app_config()
+            base_url = app_config.llm.openai_compatible.base_url
+
+        if not base_url:
+            return None
+
+        # Ensure a scheme is present and drop any trailing slash so we can
+        # safely append paths like "/models".
+        if not base_url.startswith(("http://", "https://")):
+            base_url = f"http://{base_url}"
+
+        return base_url.rstrip("/")
+
+    def _get_api_key(self, config=None) -> str:
+        """Get the current API key. Optional for local/keyless gateways."""
+        if config and config.get("api_key"):
+            return config["api_key"]
+
+        from ...core.config import get_app_config
+
+        app_config = get_app_config()
+        return app_config.llm.openai_compatible.api_key
+
+    def _create_headers(self, api_key: str = "") -> dict:
+        """Build request headers, including auth only when a key is set."""
+        headers = {"Content-Type": "application/json"}
+        if api_key:
+            headers["Authorization"] = f"Bearer {api_key}"
+        return headers
+
+    async def load_saved_config(self) -> dict:
+        """Load saved configuration for the OpenAI-compatible provider."""
+        from ...core.config import get_app_config
+
+        config = get_app_config()
+        return {
+            "base_url": config.llm.openai_compatible.base_url,
+            "api_key": config.llm.openai_compatible.api_key,
+            "enabled": config.llm.openai_compatible.enabled,
+            "validated": config.llm.openai_compatible.validated,
+            "validation_status": config.llm.openai_compatible.validation_status,
+            "validation_message": config.llm.openai_compatible.validation_message,
+        }
+
+    async def save_config(self, **config) -> tuple[bool, str]:
+        """Save configuration after successful validation."""
+        from datetime import datetime, timezone
+
+        from ...core.config import LLMProviderConfig, save_llm_provider_config
+
+        try:
+            base_url = self._get_base_url(config)
+            if not base_url:
+                return False, "Base URL is required"
+
+            valid, message = await self.validate_config(**config)
+
+            provider_config = LLMProviderConfig(
+                base_url=base_url,
+                api_key=config.get("api_key", ""),
+                enabled=config.get("enabled", True),
+                validated=valid,
+                last_validated=datetime.now(timezone.utc) if valid else None,
+                validation_status="configured" if valid else "error",
+                validation_message=message,
+                config_changed=False,
+            )
+
+            success = save_llm_provider_config("openai_compatible", provider_config)
+            if success:
+                self._saved_config = config.copy()
+                return True, "Configuration saved successfully"
+            else:
+                return False, "Failed to save configuration"
+
+        except Exception as e:
+            return False, f"Error saving configuration: {str(e)}"
+
+    def is_enabled(self) -> bool:
+        """Check if this provider is enabled."""
+        from ...core.config import get_app_config
+
+        config = get_app_config()
+        return config.llm.openai_compatible.enabled
+
+    async def set_enabled(self, enabled: bool) -> bool:
+        """Enable or disable this provider."""
+        from ...core.config import get_app_config, save_llm_provider_config
+
+        try:
+            config = get_app_config()
+            config.llm.openai_compatible.enabled = enabled
+            if not enabled:
+                config.llm.openai_compatible.validation_status = "disabled"
+            else:
+                if config.llm.openai_compatible.validated and config.llm.openai_compatible.base_url:
+                    config.llm.openai_compatible.validation_status = "configured"
+                else:
+                    config.llm.openai_compatible.validation_status = "not_validated"
+            return save_llm_provider_config("openai_compatible", config.llm.openai_compatible)
+        except Exception:
+            return False
+
+    def has_config_changed(self, **new_config) -> bool:
+        """Check if configuration has changed from saved state."""
+        if not self._saved_config:
+            try:
+                import asyncio
+
+                saved = asyncio.run(self.load_saved_config())
+                self._saved_config = saved
+            except Exception:
+                return True
+
+        new_base_url = self._get_base_url(new_config) or ""
+        saved_base_url = (self._saved_config.get("base_url") or "").rstrip("/")
+
+        return new_base_url != saved_base_url or new_config.get("api_key", "") != self._saved_config.get("api_key", "")
+
+    def get_provider_state(self) -> ProviderInfo:
+        """Get current provider state including enabled/configured status."""
+        from ...core.config import get_app_config
+
+        config = get_app_config()
+
+        provider_info = self.get_provider_info()
+        provider_info.is_available = bool(config.llm.openai_compatible.base_url)
+        provider_info.is_enabled = config.llm.openai_compatible.enabled
+        provider_info.is_configured = config.llm.openai_compatible.validated
+
+        if config.llm.openai_compatible.enabled:
+            if config.llm.openai_compatible.validated:
+                provider_info.validation_status = "configured"
+                provider_info.validation_message = "Configured"
+            else:
+                provider_info.validation_status = config.llm.openai_compatible.validation_status or "not_validated"
+                provider_info.validation_message = config.llm.openai_compatible.validation_message
+        else:
+            provider_info.validation_status = "disabled"
+            provider_info.validation_message = None
+
+        provider_info.config_changed = config.llm.openai_compatible.config_changed
+
+        return provider_info
+
+    @classmethod
+    def get_provider_info(cls) -> ProviderInfo:
+        """Get information about the OpenAI-compatible provider."""
+        return ProviderInfo(
+            id="openai_compatible",
+            name="OpenAI-Compatible",
+            description="Connect to any OpenAI-compatible endpoint such as LiteLLM, vLLM, or another gateway. "
+            "The Base URL should point at the API root that serves /models and /chat/completions "
+            "(commonly ending in /v1).",
+            setup_fields=[
+                {
+                    "name": "base_url",
+                    "type": "text",
+                    "label": "Base URL",
+                    "placeholder": "http://litellm.local:4000/v1",
+                    "required": True,
+                },
+                {
+                    "name": "api_key",
+                    "type": "password",
+                    "label": "API Key",
+                    "placeholder": "Optional (leave blank if not required)",
+                    "required": False,
+                },
+            ],
+        )
+
+    async def validate_config(self, **config) -> tuple[bool, str]:
+        """Validate the configuration by listing models."""
+        base_url = self._get_base_url(config)
+        if not base_url:
+            return False, "Base URL is required"
+
+        api_key = self._get_api_key(config)
+
+        try:
+            headers = self._create_headers(api_key)
+            async with httpx.AsyncClient(timeout=10.0) as client:
+                response = await client.get(f"{base_url}/models", headers=headers)
+
+                if response.status_code == 200:
+                    return True, "Connected successfully"
+                elif response.status_code in (401, 403):
+                    return False, "Authentication failed - check your API key"
+                elif response.status_code == 404:
+                    return False, "No /models endpoint found - check the Base URL (it often ends in /v1)"
+                else:
+                    return False, f"API error: HTTP {response.status_code}"
+
+        except httpx.TimeoutException:
+            return False, "Connection timeout - check the URL and network"
+        except httpx.ConnectError:
+            return False, "Connection failed - check the URL and network"
+        except Exception as e:
+            return False, f"Connection error: {str(e)}"
+
+    async def get_available_models(self) -> List[ModelInfo]:
+        """Get list of models advertised by the endpoint."""
+        base_url = self._get_base_url()
+        if not base_url:
+            return []
+
+        try:
+            api_key = self._get_api_key()
+            headers = self._create_headers(api_key)
+
+            async with httpx.AsyncClient(timeout=30.0) as client:
+                response = await client.get(f"{base_url}/models", headers=headers)
+
+                if response.status_code != 200:
+                    logger.error(f"Failed to get models from {base_url}: HTTP {response.status_code}")
+                    return []
+
+                models_data = response.json()
+                models = []
+
+                for model in models_data.get("data", []):
+                    model_id = model.get("id", "")
+                    if not model_id:
+                        continue
+
+                    models.append(
+                        ModelInfo(
+                            id=model_id,
+                            name=model_id,
+                            supports_streaming=True,
+                        )
+                    )
+
+                models.sort(key=lambda model: model.name.lower())
+                return models
+
+        except Exception as e:
+            logger.error(f"Failed to get models from OpenAI-compatible endpoint: {e}")
+            return []
+
+    async def process_chapter_titles(
+        self,
+        titles: List[str],
+        model_id: str,
+        additional_instructions: Optional[List[str]] = None,
+        deselect_non_chapters: bool = True,
+        infer_opening_credits: bool = True,
+        infer_end_credits: bool = True,
+        preferred_titles: Optional[List[str]] = None,
+        book: Optional[Book] = None,
+    ) -> List[Optional[str]]:
+        """Refine chapter titles using an OpenAI-compatible endpoint."""
+
+        if not titles:
+            return []
+
+        additional_instructions = additional_instructions or []
+
+        self._notify_progress(0, "Sending request…")
+
+        system_prompt = self._build_system_prompt(
+            deselect_non_chapters=deselect_non_chapters,
+            infer_opening_credits=infer_opening_credits,
+            infer_end_credits=infer_end_credits,
+            preferred_titles=preferred_titles,
+            additional_instructions=additional_instructions,
+            book=book,
+        )
+
+        chapter_data = [{"id": idx, "title": text} for idx, text in enumerate(titles)]
+
+        try:
+            base_url = self._get_base_url()
+            if not base_url:
+                logger.error("OpenAI-compatible base URL not configured")
+                self._notify_progress(0, "Provider not configured")
+                raise ValueError("OpenAI-compatible base URL not configured")
+
+            headers = self._create_headers(self._get_api_key())
+
+            total_chapters = len(titles)
+
+            base_payload = {
+                "model": model_id,
+                "messages": [
+                    {"role": "system", "content": system_prompt},
+                    {"role": "user", "content": json.dumps(chapter_data)},
+                ],
+                "stream": True,
+            }
+
+            # Request JSON output, but fall back to a plain request if the
+            # endpoint/model rejects response_format. A generic OpenAI-compatible
+            # gateway fronts many backends, not all of which support it.
+            attempts = [
+                {**base_payload, "response_format": {"type": "json_object"}},
+                base_payload,
+            ]
+
+            content_received = ""
+
+            async with httpx.AsyncClient(timeout=120.0) as client:
+                for attempt_index, payload in enumerate(attempts):
+                    is_last_attempt = attempt_index == len(attempts) - 1
+                    parser = IncrementalJSONParser()
+                    content_received = ""
+
+                    async with client.stream(
+                        "POST",
+                        f"{base_url}/chat/completions",
+                        headers=headers,
+                        json=payload,
+                        timeout=60.0,
+                    ) as response:
+                        if response.status_code != 200:
+                            await response.aread()
+                            error_text = response.text
+                            # Retry without response_format if that is what was rejected.
+                            if not is_last_attempt and response.status_code == 400 and "response_format" in error_text:
+                                logger.warning("Endpoint rejected response_format; retrying without it")
+                                continue
+                            logger.error(f"OpenAI-compatible API error: {response.status_code} - {error_text}")
+                            raise Exception(f"OpenAI-compatible API error: {response.status_code}")
+
+                        async for line in response.aiter_lines():
+                            if not line or not line.strip():
+                                continue
+
+                            line = line.strip()
+                            if not line.startswith("data: "):
+                                continue
+
+                            data_str = line[6:]  # Remove "data: " prefix
+                            if data_str == "[DONE]":
+                                break
+
+                            try:
+                                chunk = json.loads(data_str)
+                            except json.JSONDecodeError:
+                                continue
+
+                            if "choices" in chunk and len(chunk["choices"]) > 0:
+                                choice = chunk["choices"][0]
+
+                                if "delta" in choice and "content" in choice["delta"]:
+                                    content = choice["delta"]["content"]
+                                    if content:
+                                        content_received += content
+
+                                        result = parser.feed(content)
+                                        if result["new_chapters"]:
+                                            progress_percent = result["total_parsed"] / total_chapters * 100
+                                            self._notify_progress(
+                                                progress_percent,
+                                                f"Processed {result['total_parsed']}/{total_chapters} chapters",
+                                            )
+
+                    # Stream completed successfully; no need to try further variants.
+                    break
+
+            self._notify_progress(100, "Processing AI response…")
+
+            try:
+                response_data = json.loads(content_received)
+
+                if isinstance(response_data, list):
+                    processed_chapters = response_data
+                elif isinstance(response_data, dict) and "chapters" in response_data:
+                    processed_chapters = response_data["chapters"]
+                else:
+                    processed_chapters = []
+                    for value in response_data.values() if isinstance(response_data, dict) else []:
+                        if isinstance(value, list):
+                            processed_chapters = value
+                            break
+
+                if not processed_chapters:
+                    raise ValueError("No chapter array found in response")
+
+            except (json.JSONDecodeError, ValueError) as e:
+                logger.error(f"Failed to parse OpenAI-compatible response: {e}")
+                logger.error(f"Raw response: {content_received}")
+                raise
+
+            chapters = []
+            for chapter in processed_chapters:
+                if isinstance(chapter, dict):
+                    title = chapter.get("title")
+                    if title == "null" or title is None:
+                        chapters.append(None)
+                    else:
+                        chapters.append(title)
+                else:
+                    chapters.append(str(chapter) if chapter != "null" else None)
+
+            valid_chapters = len([t for t in chapters if t])
+            self._notify_progress(100, f"Generated {valid_chapters} chapter titles")
+
+            return chapters
+
+        except httpx.TimeoutException:
+            error_msg = "Request timeout - the model may be taking longer than expected"
+            logger.error("OpenAI-compatible timeout error")
+            self._notify_progress(0, error_msg)
+            raise
+        except httpx.HTTPStatusError as e:
+            error_msg = f"API error ({e.response.status_code}): {str(e)}"
+            logger.error(f"OpenAI-compatible HTTP error: {e}")
+            self._notify_progress(0, error_msg)
+            raise
+        except httpx.RequestError as e:
+            error_msg = f"Failed to connect to the endpoint - check the Base URL and network: {str(e)}"
+            logger.error(f"OpenAI-compatible connection error: {e}")
+            self._notify_progress(0, error_msg)
+            raise
+        except json.JSONDecodeError as e:
+            error_msg = f"Failed to parse response - invalid JSON format: {str(e)}"
+            logger.error(f"OpenAI-compatible JSON decode error: {e}")
+            self._notify_progress(0, error_msg)
+            raise
+        except Exception as e:
+            error_msg = f"Unexpected error during processing (model: {model_id}): {str(e)}"
+            logger.error(f"OpenAI-compatible unexpected error: {e}", exc_info=True)
+            self._notify_progress(0, error_msg)
+            raise

--- a/backend/app/services/llm_providers/openai_compatible_service.py
+++ b/backend/app/services/llm_providers/openai_compatible_service.py
@@ -59,6 +59,24 @@ class OpenAICompatibleService(AIService):
             headers["Authorization"] = f"Bearer {api_key}"
         return headers
 
+    @staticmethod
+    def _strip_code_fences(text: str) -> str:
+        """Strip Markdown code fences some models wrap JSON in despite instructions.
+
+        Handles blocks like ``` ```json ... ``` ``` by dropping the opening fence
+        line (with any language hint) and the closing fence. Returns the input
+        unchanged when no leading fence is present.
+        """
+        stripped = text.strip()
+        if not stripped.startswith("```"):
+            return stripped
+
+        lines = stripped.splitlines()
+        lines = lines[1:]  # Drop the opening fence (e.g. ``` or ```json).
+        if lines and lines[-1].strip().startswith("```"):
+            lines = lines[:-1]  # Drop the closing fence.
+        return "\n".join(lines).strip()
+
     async def load_saved_config(self) -> dict:
         """Load saved configuration for the OpenAI-compatible provider."""
         from ...core.config import get_app_config
@@ -393,7 +411,7 @@ class OpenAICompatibleService(AIService):
             self._notify_progress(100, "Processing AI response…")
 
             try:
-                response_data = json.loads(content_received)
+                response_data = json.loads(self._strip_code_fences(content_received))
 
                 if isinstance(response_data, list):
                     processed_chapters = response_data

--- a/backend/app/services/llm_providers/registry.py
+++ b/backend/app/services/llm_providers/registry.py
@@ -10,6 +10,7 @@ from .copilot_service import CopilotService
 from .gemini_service import GeminiService
 from .lm_studio_service import LMStudioService
 from .ollama_service import OllamaService
+from .openai_compatible_service import OpenAICompatibleService
 from .openai_service import OpenAIService
 from .openrouter_service import OpenRouterService
 
@@ -42,6 +43,7 @@ class ProviderRegistry:
         self.register_provider(OpenRouterService)
         self.register_provider(OllamaService)
         self.register_provider(LMStudioService)
+        self.register_provider(OpenAICompatibleService)
 
     def register_provider(self, provider_class: Type[AIService]):
         """Register a new provider"""

--- a/backend/tests/llm_providers/test_openai_compatible_service.py
+++ b/backend/tests/llm_providers/test_openai_compatible_service.py
@@ -1,0 +1,106 @@
+"""Tests for the generic OpenAI-compatible provider.
+
+Exercises the HTTP surface (model discovery, validation, and the streaming
+chat-completions call) against a mocked endpoint, including the fallback that
+retries without ``response_format`` when a backend rejects it.
+"""
+
+import json
+
+import pytest
+
+from app.core import config as C
+from app.services.llm_providers.openai_compatible_service import OpenAICompatibleService
+
+BASE_URL = "http://litellm.test/v1"
+
+
+@pytest.fixture
+def configured(monkeypatch):
+    """Install a saved config pointing at the mocked endpoint."""
+    app_cfg = C.AppConfig()
+    app_cfg.llm.openai_compatible.base_url = BASE_URL
+    app_cfg.llm.openai_compatible.api_key = "sk-test"
+    monkeypatch.setattr(C, "_app_config", app_cfg)
+    return app_cfg
+
+
+def make_service():
+    return OpenAICompatibleService(lambda *a, **k: None)
+
+
+def sse(obj) -> bytes:
+    """Encode a chat-completions object as a minimal SSE stream."""
+    delta = {"choices": [{"delta": {"content": json.dumps(obj)}}]}
+    return ("data: " + json.dumps(delta) + "\n\n" + "data: [DONE]\n\n").encode()
+
+
+def test_base_url_normalization():
+    svc = make_service()
+    assert svc._get_base_url({"base_url": "host:4000/v1/"}) == "http://host:4000/v1"
+    assert svc._get_base_url({"base_url": "https://x/v1"}) == "https://x/v1"
+    assert svc._get_base_url({"base_url": ""}) is None
+
+
+async def test_validate_config_missing_base_url():
+    ok, msg = await make_service().validate_config(base_url="")
+    assert ok is False
+    assert "Base URL" in msg
+
+
+async def test_validate_config_success(httpx_mock):
+    httpx_mock.add_response(url=f"{BASE_URL}/models", json={"data": []})
+    ok, msg = await make_service().validate_config(base_url=BASE_URL, api_key="sk-test")
+    assert ok is True
+
+
+async def test_validate_config_auth_failure(httpx_mock):
+    httpx_mock.add_response(url=f"{BASE_URL}/models", status_code=401)
+    ok, msg = await make_service().validate_config(base_url=BASE_URL, api_key="bad")
+    assert ok is False
+    assert "Authentication" in msg
+
+
+async def test_get_available_models_sorted(configured, httpx_mock):
+    httpx_mock.add_response(
+        url=f"{BASE_URL}/models",
+        json={"data": [{"id": "llama-3.1-70b"}, {"id": "gpt-4o-mini"}, {"id": ""}]},
+    )
+    models = await make_service().get_available_models()
+    # Sorted case-insensitively; the entry with an empty id is dropped.
+    assert [m.id for m in models] == ["gpt-4o-mini", "llama-3.1-70b"]
+
+
+async def test_process_chapter_titles_happy_path(configured, httpx_mock):
+    obj = {"chapters": [{"id": 0, "title": "Chapter 1"}, {"id": 1, "title": None}]}
+    httpx_mock.add_response(url=f"{BASE_URL}/chat/completions", content=sse(obj))
+
+    result = await make_service().process_chapter_titles(["chapter one", "noise"], "gpt-4o-mini")
+    assert result == ["Chapter 1", None]
+
+    request = httpx_mock.get_request()
+    assert json.loads(request.content)["response_format"] == {"type": "json_object"}
+
+
+async def test_process_chapter_titles_falls_back_without_response_format(configured, httpx_mock):
+    # First attempt: backend rejects response_format.
+    httpx_mock.add_response(
+        url=f"{BASE_URL}/chat/completions",
+        status_code=400,
+        json={"error": {"message": "response_format is not supported by this model"}},
+    )
+    # Second attempt: succeeds without it.
+    obj = {"chapters": [{"id": 0, "title": "Chapter 1"}]}
+    httpx_mock.add_response(url=f"{BASE_URL}/chat/completions", content=sse(obj))
+
+    result = await make_service().process_chapter_titles(["chapter one"], "some-model")
+    assert result == ["Chapter 1"]
+
+    requests = httpx_mock.get_requests()
+    assert len(requests) == 2
+    assert "response_format" in json.loads(requests[0].content)
+    assert "response_format" not in json.loads(requests[1].content)
+
+
+async def test_process_chapter_titles_empty_input():
+    assert await make_service().process_chapter_titles([], "gpt-4o-mini") == []

--- a/backend/tests/llm_providers/test_openai_compatible_service.py
+++ b/backend/tests/llm_providers/test_openai_compatible_service.py
@@ -15,14 +15,20 @@ from app.services.llm_providers.openai_compatible_service import OpenAICompatibl
 BASE_URL = "http://litellm.test/v1"
 
 
-@pytest.fixture
-def configured(monkeypatch):
-    """Install a saved config pointing at the mocked endpoint."""
+@pytest.fixture(autouse=True)
+def isolated_config(monkeypatch):
+    """Use an isolated default config for tests."""
     app_cfg = C.AppConfig()
-    app_cfg.llm.openai_compatible.base_url = BASE_URL
-    app_cfg.llm.openai_compatible.api_key = "sk-test"
     monkeypatch.setattr(C, "_app_config", app_cfg)
     return app_cfg
+
+
+@pytest.fixture
+def configured(isolated_config):
+    """Point the isolated config at the mocked endpoint."""
+    isolated_config.llm.openai_compatible.base_url = BASE_URL
+    isolated_config.llm.openai_compatible.api_key = "sk-test"
+    return isolated_config
 
 
 def make_service():
@@ -100,6 +106,17 @@ async def test_process_chapter_titles_falls_back_without_response_format(configu
     assert len(requests) == 2
     assert "response_format" in json.loads(requests[0].content)
     assert "response_format" not in json.loads(requests[1].content)
+
+
+async def test_process_chapter_titles_strips_markdown_fences(configured, httpx_mock):
+    obj = {"chapters": [{"id": 0, "title": "Chapter 1"}]}
+    fenced = "```json\n" + json.dumps(obj) + "\n```"
+    delta = {"choices": [{"delta": {"content": fenced}}]}
+    content = ("data: " + json.dumps(delta) + "\n\n" + "data: [DONE]\n\n").encode()
+    httpx_mock.add_response(url=f"{BASE_URL}/chat/completions", content=content)
+
+    result = await make_service().process_chapter_titles(["chapter one"], "gpt-4o-mini")
+    assert result == ["Chapter 1"]
 
 
 async def test_process_chapter_titles_empty_input():

--- a/docs/getting-started/setup-llm-providers.md
+++ b/docs/getting-started/setup-llm-providers.md
@@ -24,6 +24,7 @@ See the relevant provider card below for setup steps.
 | [GitHub Copilot](#github-copilot) | Free/Paid | Personal access token | Free tier has limited [model selection](https://docs.github.com/en/copilot/reference/ai-models/supported-models#supported-ai-models-per-copilot-plan){:target="_blank"} and a limited monthly allowance of [GitHub AI credits](https://docs.github.com/en/copilot/concepts/billing/usage-based-billing-for-individuals){:target="_blank"}, consumed based on token usage. |
 | [Ollama](#ollama) | Free (self-hosted) | Host URL | Local, private, unlimited. Small models do not work well; try to use 16B+ parameter models. |
 | [LM Studio](#lm-studio) | Free (self-hosted) | Host URL | Local, private, unlimited. Small models do not work well; try to use 16B+ parameter models. |
+| [OpenAI-Compatible](#openai-compatible) | Varies | Base URL + optional API key | Connect to any OpenAI-compatible endpoint (e.g. LiteLLM, vLLM). Available models and cost depend on the endpoint you point it at. |
 
 ---
 
@@ -102,6 +103,18 @@ See the relevant provider card below for setup steps.
     Install [LM Studio](https://lmstudio.ai/){:target="_blank"}, download a model from the **Discover** tab, then start the local server from the **Developer** tab. LM Studio listens on `http://localhost:1234` by default.
 
     In Achew, go to **Settings -> LLM Setup** and enable the LM Studio card. Enter the host URL into the input field, then click **Validate**. Once validated, you can use LM Studio as a provider for AI Cleanup in the chapter editor.
+
+    !!! tip "Model size matters"
+        Small models rarely produce usable results. Try to use 16B+ parameter models if possible.
+
+<a id="openai-compatible"></a>
+??? example "OpenAI-Compatible"
+    This provider connects to any endpoint that implements the OpenAI REST API — for example [LiteLLM](https://docs.litellm.ai/){:target="_blank"}, [vLLM](https://docs.vllm.ai/){:target="_blank"}, or another self-hosted gateway. It lists whatever models the endpoint advertises, so you pick the specific model at cleanup time.
+
+    In Achew, go to **Settings -> LLM Setup** and enable the OpenAI-Compatible card. Enter the **Base URL** of the endpoint's API root — the path that serves `/models` and `/chat/completions`, commonly ending in `/v1` (e.g. `http://litellm.local:4000/v1`). Provide an **API Key** if the endpoint requires one, or leave it blank for keyless gateways. Click **Validate**, and once connected you can use it as a provider for AI Cleanup in the chapter editor.
+
+    !!! tip "Docker networking"
+        If Achew runs in a container, `localhost` refers to the container itself. Point the Base URL at the host or LAN IP instead (e.g. `http://host.docker.internal:4000/v1` on macOS/Windows).
 
     !!! tip "Model size matters"
         Small models rarely produce usable results. Try to use 16B+ parameter models if possible.


### PR DESCRIPTION
## Summary

Adds a generic **OpenAI-Compatible** provider for AI Cleanup, letting Achew
connect to any endpoint that implements the OpenAI REST API — e.g. LiteLLM,
vLLM, or another self-hosted gateway — via a base URL and optional API key.

Every existing provider hardcodes its endpoint (or uses a vendor SDK), so
there was previously no way to use a self-hosted OpenAI-compatible gateway.
This adds a single configurable provider that covers all of them.

## What it does

- Discovers models from `GET {base_url}/models` (no vendor-specific filtering)
- Generates via streamed `POST {base_url}/chat/completions`
- API key is optional, so keyless local gateways work
- Normalizes the base URL (adds a scheme if missing, strips a trailing slash)
- Falls back to a request without `response_format` if the backend rejects it,
  since a generic gateway fronts models that don't all support JSON mode

## Implementation

- New `OpenAICompatibleService`, registered in the provider registry
- Adds a `base_url` field and an `openai_compatible` section to the config
- Wires up the model-listing and cancel-changes routes
- No frontend changes needed — the settings UI is data-driven from `setup_fields`

## Docs & tests

- Documented in `docs/getting-started/setup-llm-providers.md`
  (summary-table row + setup example)
- Adds `tests/llm_providers/test_openai_compatible_service.py` — 8 tests covering
  URL normalization, validation, model listing, the streaming happy path, the
  `response_format` fallback, and empty input
- Also gitignores the repo-root `config/` and `cache/` dirs that the documented
  docker-compose workflow creates at runtime

## Testing

- `ruff check` / `ruff format` clean; `pyright` (basic mode) reports 0 errors
- Full backend suite passes (185 passed, 2 pre-existing xfailed)
- Verified end-to-end against a live LiteLLM instance: model discovery,
  validation, and AI Cleanup all succeed
