### PR TITLE
Allow SSL skip for LLM providers, misc provider cleanup

### DIFF
--- a/backend/app/api/routes/config.py
+++ b/backend/app/api/routes/config.py
@@ -537,15 +537,23 @@ async def get_llm_provider_models(provider_id: str):
                 raise HTTPException(status_code=400, detail="OpenRouter provider not configured")
             provider_config = {"api_key": config.llm.openrouter.api_key}
         elif provider_id == "ollama":
-            provider_config = {"host": config.llm.ollama.host or "http://localhost:11434"}
+            provider_config = {
+                "host": config.llm.ollama.host or "http://localhost:11434",
+                "skip_ssl_verify": config.llm.ollama.skip_ssl_verify,
+            }
         elif provider_id == "lm_studio":
-            provider_config = {"host": config.llm.lm_studio.host or "http://localhost:1234"}
+            provider_config = {
+                "host": config.llm.lm_studio.host or "http://localhost:1234",
+                "api_key": config.llm.lm_studio.api_key,
+                "skip_ssl_verify": config.llm.lm_studio.skip_ssl_verify,
+            }
         elif provider_id == "openai_compatible":
             if not config.llm.openai_compatible.base_url:
                 raise HTTPException(status_code=400, detail="OpenAI-compatible provider not configured")
             provider_config = {
                 "base_url": config.llm.openai_compatible.base_url,
                 "api_key": config.llm.openai_compatible.api_key,
+                "skip_ssl_verify": config.llm.openai_compatible.skip_ssl_verify,
             }
 
         models = await get_provider_models(provider_id, **provider_config)

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -30,6 +30,7 @@ class LLMProviderConfig(BaseModel):
     api_key: str = ""
     host: str = ""  # For providers like Ollama
     base_url: str = ""  # For OpenAI-compatible endpoints (e.g. LiteLLM)
+    skip_ssl_verify: bool = False  # Skip TLS certificate verification (self-signed certs)
     validated: bool = False
     last_validated: Optional[datetime] = None
     enabled: bool = False  # Default to disabled

--- a/backend/app/services/llm_providers/base.py
+++ b/backend/app/services/llm_providers/base.py
@@ -13,6 +13,13 @@ from app.models.progress import ProgressCallback
 logger = logging.getLogger(__name__)
 
 
+def coerce_bool(value: Any) -> bool:
+    """Coerce a config value to bool, treating the strings "false"/"0"/"" as False."""
+    if isinstance(value, str):
+        return value.strip().lower() not in ("", "0", "false", "no", "off")
+    return bool(value)
+
+
 class Chapter(BaseModel):
     id: float
     title: Optional[str]
@@ -20,6 +27,42 @@ class Chapter(BaseModel):
 
 class ChapterList(BaseModel):
     chapters: list[Chapter]
+
+
+# JSON schema for the chapter list every provider requests and parses. The
+# array is wrapped in an object because OpenAI-style structured outputs forbid
+# root arrays; the shared prompt and input data use the same wrapper, so the
+# machine constraint and the prompt agree. Backends that ignore the schema
+# still work: _extract_chapter_array accepts a bare array too.
+CHAPTERS_SCHEMA = {
+    "type": "object",
+    "properties": {
+        "chapters": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "id": {"type": "integer"},
+                    "title": {"type": ["string", "null"]},
+                },
+                "required": ["id", "title"],
+                "additionalProperties": False,
+            },
+        }
+    },
+    "required": ["chapters"],
+    "additionalProperties": False,
+}
+
+# The same schema in OpenAI-style chat-completions response_format clothing.
+CHAPTERS_RESPONSE_FORMAT = {
+    "type": "json_schema",
+    "json_schema": {
+        "name": "chapters",
+        "strict": True,
+        "schema": CHAPTERS_SCHEMA,
+    },
+}
 
 
 class IncrementalJSONParser:
@@ -97,6 +140,10 @@ class ProviderInfo(BaseModel):
 class AIService(ABC):
     """Abstract base class for LLM providers"""
 
+    # Whether model lists may be cached (see registry). Self-hosted providers
+    # disable this so newly added/removed models show up immediately.
+    CACHE_MODELS: bool = True
+
     def __init__(self, progress_callback: ProgressCallback, **config):
         self.progress_callback = progress_callback
         self.config = config
@@ -106,6 +153,56 @@ class AIService(ABC):
     def _notify_progress(self, percent: float, message: str = ""):
         """Notify progress via callback"""
         self.progress_callback(Step.AI_CLEANUP, percent, message, {})
+
+    @staticmethod
+    def _strip_code_fences(text: str) -> str:
+        """Strip Markdown code fences some models wrap JSON in despite instructions.
+
+        Handles blocks like ``` ```json ... ``` ``` by dropping the opening fence
+        line (with any language hint) and the closing fence. Returns the input
+        unchanged when no leading fence is present.
+        """
+        stripped = text.strip()
+        if not stripped.startswith("```"):
+            return stripped
+
+        lines = stripped.splitlines()
+        lines = lines[1:]  # Drop the opening fence (e.g. ``` or ```json).
+        if lines and lines[-1].strip().startswith("```"):
+            lines = lines[:-1]  # Drop the closing fence.
+        return "\n".join(lines).strip()
+
+    @staticmethod
+    def _build_chapter_input(titles: List[str]) -> str:
+        """Serialize the input titles as the {"chapters": [...]} JSON the prompt describes."""
+        return json.dumps({"chapters": [{"id": idx, "title": text} for idx, text in enumerate(titles)]})
+
+    @staticmethod
+    def _extract_chapter_array(content: str) -> list:
+        """Pull the chapter array out of a raw model response.
+
+        Strips Markdown code fences, then accepts a bare array, a
+        ``{"chapters": [...]}`` wrapper, or any object containing a list value.
+        Raises ``json.JSONDecodeError`` or ``ValueError`` when no chapter array
+        can be found.
+        """
+        response_data = json.loads(AIService._strip_code_fences(content))
+
+        if isinstance(response_data, list):
+            processed_chapters = response_data
+        elif isinstance(response_data, dict) and isinstance(response_data.get("chapters"), list):
+            processed_chapters = response_data["chapters"]
+        else:
+            processed_chapters = []
+            for value in response_data.values() if isinstance(response_data, dict) else []:
+                if isinstance(value, list):
+                    processed_chapters = value
+                    break
+
+        if not processed_chapters:
+            raise ValueError("No chapter array found in response")
+
+        return processed_chapters
 
     @classmethod
     @abstractmethod
@@ -168,8 +265,8 @@ class AIService(ABC):
 
         # Base prompt
         base_prompt = """You are a helpful assistant that validates and cleans up audiobook chapter titles.
-You will receive a JSON array of objects, each containing a chapter index (int) and a raw text transcript of the title. Note that there may be inaccuracies in the transcripts.
-You will output the same array, but with processed titles. You must respond with ONLY the raw JSON data - no additional text, comments, or markdown."""
+You will receive a JSON object with a "chapters" array, each item containing a chapter index (int) and a raw text transcript of the title. Note that there may be inaccuracies in the transcripts.
+You will output the same structure, but with processed titles. You must respond with ONLY the raw JSON data - no additional text, comments, or markdown."""
 
         if book_title and book_author:
             base_prompt += f'\n\nThe book is titled "{book_title}" by {book_author}.'

--- a/backend/app/services/llm_providers/claude_service.py
+++ b/backend/app/services/llm_providers/claude_service.py
@@ -6,7 +6,7 @@ import anthropic
 
 from app.models.abs import Book
 
-from .base import AIService, Chapter, IncrementalJSONParser, ModelInfo, ProviderInfo
+from .base import AIService, ChapterList, IncrementalJSONParser, ModelInfo, ProviderInfo
 
 logger = logging.getLogger(__name__)
 
@@ -286,8 +286,7 @@ class ClaudeService(AIService):
         )
 
         # Create JSON input for all chapters
-        chapter_data = [{"id": idx, "title": text} for idx, text in enumerate(titles)]
-        user_message = f"Input data:\n{json.dumps(chapter_data)}"
+        user_message = f"Input data:\n{self._build_chapter_input(titles)}"
 
         try:
             # Get API key and create client
@@ -328,7 +327,7 @@ class ClaudeService(AIService):
 
             if supports_structured_output:
                 stream_kwargs["betas"] = ["structured-outputs-2025-11-13"]
-                stream_kwargs["output_format"] = List[Chapter]
+                stream_kwargs["output_format"] = ChapterList
 
             async with processing_client.beta.messages.stream(**stream_kwargs) as stream:
                 async for text in stream.text_stream:
@@ -351,9 +350,9 @@ class ClaudeService(AIService):
 
             # Parse the response
             try:
-                processed_chapters = json.loads(content_received)
+                processed_chapters = self._extract_chapter_array(content_received)
 
-            except json.JSONDecodeError as e:
+            except (json.JSONDecodeError, ValueError) as e:
                 logger.error(f"Claude Failed to parse Claude response as JSON: {e}")
                 logger.error(f"Claude Raw response: {content_received}")
                 raise

--- a/backend/app/services/llm_providers/copilot_service.py
+++ b/backend/app/services/llm_providers/copilot_service.py
@@ -2,7 +2,6 @@ import asyncio
 import json
 import logging
 import os
-import re
 import time
 from typing import List, Optional
 
@@ -339,8 +338,6 @@ class CopilotService(AIService):
             book=book,
         )
 
-        chapter_data = [{"id": idx, "title": text} for idx, text in enumerate(titles)]
-
         try:
             github_token = self._get_github_token()
             if not github_token:
@@ -389,7 +386,7 @@ class CopilotService(AIService):
                 ) as session:
                     session.on(on_event)
 
-                    message = f"{system_prompt}\n\n{json.dumps(chapter_data)}"
+                    message = f"{system_prompt}\n\n{self._build_chapter_input(titles)}"
                     await session.send(message)
 
                     start = time.monotonic()
@@ -407,29 +404,8 @@ class CopilotService(AIService):
 
             self._notify_progress(100, "Processing AI response…")
 
-            # Strip markdown code block wrapping (```json ... ```) that may have been added
-            stripped = content_received.strip()
-            match = re.match(r"^```(?:json)?\s*\n?(.*?)\n?\s*```$", stripped, re.DOTALL)
-            if match:
-                stripped = match.group(1).strip()
-
             try:
-                response_data = json.loads(stripped)
-
-                if isinstance(response_data, list):
-                    processed_chapters = response_data
-                elif isinstance(response_data, dict) and "chapters" in response_data:
-                    processed_chapters = response_data["chapters"]
-                else:
-                    processed_chapters = []
-                    for value in response_data.values() if isinstance(response_data, dict) else []:
-                        if isinstance(value, list):
-                            processed_chapters = value
-                            break
-
-                if not processed_chapters:
-                    raise ValueError("No chapter array found in response")
-
+                processed_chapters = self._extract_chapter_array(content_received)
             except (json.JSONDecodeError, ValueError) as e:
                 logger.error(f"Failed to parse Copilot response: {e}")
                 logger.error(f"Raw response: {content_received!r}")

--- a/backend/app/services/llm_providers/gemini_service.py
+++ b/backend/app/services/llm_providers/gemini_service.py
@@ -303,8 +303,7 @@ class GeminiService(AIService):
         )
 
         # Create JSON input for all chapters
-        chapter_data = [{"id": idx, "title": text} for idx, text in enumerate(titles)]
-        user_message = f"Input data:\n{json.dumps(chapter_data)}"
+        user_message = f"Input data:\n{self._build_chapter_input(titles)}"
 
         # Retry on JSON decode errors
         max_retries = 1
@@ -383,10 +382,9 @@ class GeminiService(AIService):
 
                 # Parse the response
                 try:
-                    response_data = json.loads(content_received)
-                    processed_chapters = response_data.get("chapters", [])
+                    processed_chapters = self._extract_chapter_array(content_received)
 
-                except json.JSONDecodeError as e:
+                except (json.JSONDecodeError, ValueError) as e:
                     logger.error(f"Gemini Failed to parse Gemini response as JSON: {e}")
                     logger.error(f"Gemini Raw response: {content_received}")
 

--- a/backend/app/services/llm_providers/lm_studio_service.py
+++ b/backend/app/services/llm_providers/lm_studio_service.py
@@ -1,28 +1,37 @@
-import asyncio
 import json
 import logging
 import time
 from typing import List, Optional
 
-from lmstudio import AsyncClient
+import httpx
 
 from app.models.abs import Book
 
-from .base import AIService, IncrementalJSONParser, ModelInfo, ProviderInfo
+from .base import CHAPTERS_RESPONSE_FORMAT, AIService, IncrementalJSONParser, ModelInfo, ProviderInfo, coerce_bool
 
 logger = logging.getLogger(__name__)
 
+# Model loading can take a while on first use, so allow generous read timeouts.
+REQUEST_TIMEOUT = httpx.Timeout(300.0, connect=10.0)
+
 
 class LMStudioService(AIService):
-    """LM Studio implementation of AIService for local models"""
+    """LM Studio implementation of AIService for local models.
+
+    Talks to LM Studio's REST API over HTTP(S): ``GET {host}/api/v0/models``
+    for model discovery (with a fallback to the OpenAI-compatible
+    ``/v1/models``) and ``POST {host}/v1/chat/completions`` for generation.
+    Using the REST API instead of the websocket SDK allows optional API token
+    authentication and HTTPS hosts (including self-signed certificates).
+    """
+
+    # Self-hosted: the user controls the model list, so always fetch it fresh.
+    CACHE_MODELS = False
 
     def __init__(self, progress_callback, **config):
         super().__init__(progress_callback, **config)
 
-        # Do not create client or validate host here - defer until needed
-        # This allows safe instantiation for config/state purposes
-
-    def _get_host(self, config=None):
+    def _get_host(self, config=None) -> Optional[str]:
         """Get the current host from config or saved configuration"""
         # First try from passed config
         if config and config.get("host"):
@@ -41,23 +50,69 @@ class LMStudioService(AIService):
         if not host.startswith(("http://", "https://")):
             host = f"http://{host}"
 
-        return host
+        return host.rstrip("/")
 
-    def _create_client(self, host=None):
-        """Create an LM Studio client with the given or current host"""
-        if not host:
-            host = self._get_host()
+    def _get_api_key(self, config=None) -> str:
+        """Get the current API token. Optional unless authentication is enabled in LM Studio."""
+        if config and config.get("api_key"):
+            return config["api_key"]
 
-        if not host:
-            raise ValueError("LM Studio host configuration is required")
+        from ...core.config import get_app_config
 
-        # Remove http:// or https:// prefix for LM Studio client
-        if host.startswith("http://"):
-            host = host[7:]
-        elif host.startswith("https://"):
-            host = host[8:]
+        app_config = get_app_config()
+        return app_config.llm.lm_studio.api_key
 
-        return AsyncClient(host)
+    def _get_skip_ssl_verify(self, config=None) -> bool:
+        """Get whether TLS certificate verification should be skipped."""
+        if config and "skip_ssl_verify" in config:
+            return coerce_bool(config["skip_ssl_verify"])
+
+        from ...core.config import get_app_config
+
+        app_config = get_app_config()
+        return app_config.llm.lm_studio.skip_ssl_verify
+
+    def _create_headers(self, api_key: str = "") -> dict:
+        """Build request headers, including auth only when a token is set."""
+        headers = {"Content-Type": "application/json"}
+        if api_key:
+            headers["Authorization"] = f"Bearer {api_key}"
+        return headers
+
+    @staticmethod
+    def _extract_error_message(error_text: str) -> str:
+        """Pull the human-readable message out of an OpenAI-style JSON error body.
+
+        Falls back to the raw (truncated) body when it isn't JSON; returns an
+        empty string when there is no useful detail.
+        """
+        try:
+            error = json.loads(error_text).get("error", "")
+            if isinstance(error, dict):
+                error = error.get("message", "")
+            if isinstance(error, str):
+                return error.strip()[:300]
+        except (json.JSONDecodeError, AttributeError):
+            pass
+        return error_text.strip()[:300]
+
+    async def _model_not_loaded(self, client: httpx.AsyncClient, host: str, headers: dict, model_id: str) -> bool:
+        """Check whether a chat failure is explained by an unloaded model.
+
+        LM Studio only loads models on demand when JIT model loading is enabled
+        in its server settings; with it disabled, requests against an unloaded
+        model fail. Best-effort: any error here means "don't know", not "yes".
+        """
+        try:
+            response = await client.get(f"{host}/api/v0/models", headers=headers, timeout=10.0)
+            if response.status_code != 200:
+                return False
+            for model in response.json().get("data", []):
+                if model.get("id") == model_id:
+                    return model.get("state") == "not-loaded"
+        except Exception as e:
+            logger.debug(f"LM Studio model state check failed: {e}")
+        return False
 
     async def load_saved_config(self) -> dict:
         """Load saved configuration for LM Studio provider"""
@@ -66,6 +121,8 @@ class LMStudioService(AIService):
         config = get_app_config()
         return {
             "host": config.llm.lm_studio.host or "",
+            "api_key": config.llm.lm_studio.api_key,
+            "skip_ssl_verify": config.llm.lm_studio.skip_ssl_verify,
             "enabled": config.llm.lm_studio.enabled,
             "validated": config.llm.lm_studio.validated,
             "validation_status": config.llm.lm_studio.validation_status,
@@ -82,14 +139,21 @@ class LMStudioService(AIService):
             # Get and validate host
             host = self._get_host(config)
             if not host:
-                return False, "LM Studio host configuration is required"
+                return False, "LM Studio server URL is required"
 
             # Validate first
             valid, message = await self.validate_config(**config)
 
+            # The frontend omits the api_key field when it is unchanged (it only
+            # ever sees a masked value), so fall back to the saved token rather
+            # than wiping it. An explicit empty string still clears it.
+            api_key = config["api_key"] if "api_key" in config else self._get_api_key()
+
             # Save configuration
             provider_config = LLMProviderConfig(
                 host=host,
+                api_key=api_key,
+                skip_ssl_verify=self._get_skip_ssl_verify(config),
                 enabled=config.get("enabled", True),
                 validated=valid,
                 last_validated=datetime.now(timezone.utc) if valid else None,
@@ -115,9 +179,8 @@ class LMStudioService(AIService):
         config = get_app_config()
         return config.llm.lm_studio.enabled
 
-    @classmethod
-    async def set_enabled_static(cls, enabled: bool) -> bool:
-        """Enable or disable this provider (class method that doesn't require instance)"""
+    async def set_enabled(self, enabled: bool) -> bool:
+        """Enable or disable this provider"""
         from ...core.config import get_app_config, save_llm_provider_config
 
         try:
@@ -135,15 +198,13 @@ class LMStudioService(AIService):
         except Exception:
             return False
 
-    async def set_enabled(self, enabled: bool) -> bool:
-        """Enable or disable this provider (instance method for compatibility)"""
-        return await self.set_enabled_static(enabled)
-
     def has_config_changed(self, **new_config) -> bool:
         """Check if configuration has changed from saved state"""
         if not self._saved_config:
             # Load saved config if not cached
             try:
+                import asyncio
+
                 saved = asyncio.run(self.load_saved_config())
                 self._saved_config = saved
             except Exception:
@@ -153,7 +214,11 @@ class LMStudioService(AIService):
         new_host = self._get_host(new_config) or ""
         saved_host = self._saved_config.get("host", "")
 
-        return new_host != saved_host
+        return (
+            new_host != saved_host
+            or new_config.get("api_key", "") != self._saved_config.get("api_key", "")
+            or self._get_skip_ssl_verify(new_config) != coerce_bool(self._saved_config.get("skip_ssl_verify", False))
+        )
 
     def get_provider_state(self) -> ProviderInfo:
         """Get current provider state including enabled/configured status"""
@@ -193,11 +258,25 @@ class LMStudioService(AIService):
                 {
                     "name": "host",
                     "type": "text",
-                    "label": "LM Studio Host URL",
-                    "placeholder": "localhost:1234",
-                    "required": False,
+                    "label": "Server URL",
+                    "placeholder": "Server URL (e.g. http://localhost:1234)",
+                    "required": True,
                     "help_url": "https://lmstudio.ai/docs/app/api",
-                }
+                },
+                {
+                    "name": "api_key",
+                    "type": "password",
+                    "label": "API Token",
+                    "placeholder": "API Token (leave blank if authentication is disabled)",
+                    "required": False,
+                },
+                {
+                    "name": "skip_ssl_verify",
+                    "type": "checkbox",
+                    "label": "Skip SSL certificate verification",
+                    "help_text": "Allows HTTPS servers with self-signed certificates. Only enable this for servers you trust.",
+                    "required": False,
+                },
             ],
             is_available=True,
         )
@@ -209,76 +288,84 @@ class LMStudioService(AIService):
 
         # Host is required
         if not host:
-            return False, "LM Studio host configuration is required"
+            return False, "LM Studio server URL is required"
 
         try:
-            # Create client using helper method
-            async with self._create_client(host) as client:
-                # Add 5-second timeout to the validation
-                try:
-                    await asyncio.wait_for(client.llm.list_downloaded(), timeout=5.0)
-                    return True, "Connected successfully"
-                except asyncio.TimeoutError:
-                    logger.error("LM Studio Connection timeout after 5 seconds")
-                    return False, "Connection timeout (5s) - check URL and network"
+            headers = self._create_headers(self._get_api_key(config))
+            verify = not self._get_skip_ssl_verify(config)
+            async with httpx.AsyncClient(timeout=10.0, verify=verify) as client:
+                response = await client.get(f"{host}/v1/models", headers=headers)
 
+                if response.status_code == 200:
+                    return True, "Connected successfully"
+                elif response.status_code in (401, 403):
+                    return False, "Authentication failed - check your API token"
+                elif response.status_code == 404:
+                    return False, "LM Studio API not found - ensure the server is running"
+                else:
+                    detail = self._extract_error_message(response.text)
+                    return False, f"LM Studio error: HTTP {response.status_code}" + (f" - {detail}" if detail else "")
+
+        except httpx.TimeoutException:
+            logger.error("LM Studio Connection timeout")
+            return False, "Connection timeout - check URL and network"
         except Exception as e:
             logger.error(f"LM Studio Validation exception: {type(e).__name__}: {e}", exc_info=True)
             return False, f"Connection failed: {str(e)}"
 
     async def get_available_models(self) -> List[ModelInfo]:
         """Get list of available LM Studio models"""
+        host = self._get_host()
+        if not host:
+            logger.warning("LM Studio No host configured, returning empty model list")
+            return []
+
         try:
-            # Get host and create client
-            host = self._get_host()
-            if not host:
-                logger.warning("LM Studio No host configured, returning empty model list")
-                return []
+            headers = self._create_headers(self._get_api_key())
+            verify = not self._get_skip_ssl_verify()
 
-            async with self._create_client(host) as client:
-                models = await client.llm.list_downloaded()
+            async with httpx.AsyncClient(timeout=30.0, verify=verify) as client:
+                # Prefer the native REST API, which includes model metadata such
+                # as architecture and context length.
+                response = await client.get(f"{host}/api/v0/models", headers=headers)
+                if response.status_code != 200:
+                    logger.info(f"LM Studio /api/v0/models returned HTTP {response.status_code}, trying /v1/models")
+                    response = await client.get(f"{host}/v1/models", headers=headers)
 
-                model_list = []
+                if response.status_code != 200:
+                    logger.error(f"Failed to get LM Studio models: HTTP {response.status_code}")
+                    return []
 
-                for model in models:
-                    logger.debug(f"LM Studio Processing model: {model}")
-
-                    try:
-                        model_info = model.info
-                        model_key = model_info.model_key
-                        display_name = model_info.display_name
-
-                        if model_key and display_name:
-                            # Get model size info if available
-                            size_info = ""
-                            if model_info.size_bytes:
-                                size_gb = model_info.size_bytes / (1024**3)
-                                size_info = f" ({size_gb:.1f}GB)"
-
-                            description = f"Local model: {model_key}"
-                            if model_info.architecture:
-                                description += f" ({model_info.architecture})"
-
-                            model_info_obj = ModelInfo(
-                                id=model_key,
-                                name=f"{display_name}{size_info}",
-                                description=description,
-                                supports_streaming=True,
-                            )
-                            model_list.append(model_info_obj)
-                            logger.debug(f"LM Studio Added model: {model_info_obj.name} (id: {model_info_obj.id})")
-                        else:
-                            logger.warning(
-                                f"LM Studio model missing required attributes: model_key={model_key}, display_name={display_name}"
-                            )
-                    except Exception as e:
-                        logger.error(f"Error processing LM Studio model {model}: {e}")
+                models = []
+                for model in response.json().get("data", []):
+                    model_id = model.get("id", "")
+                    if not model_id:
                         continue
 
-                # Sort by name for better UX
-                model_list.sort(key=lambda m: m.name.lower())
+                    # Skip non-LLM entries (e.g. embedding models) when the
+                    # native API reports a type.
+                    model_type = model.get("type")
+                    if model_type and model_type not in ("llm", "vlm"):
+                        continue
 
-                return model_list
+                    description = f"Local model: {model_id}"
+                    if model.get("arch"):
+                        description += f" ({model['arch']})"
+
+                    models.append(
+                        ModelInfo(
+                            id=model_id,
+                            name=model_id,
+                            description=description,
+                            context_length=model.get("max_context_length"),
+                            supports_streaming=True,
+                        )
+                    )
+
+                # Sort by name for better UX
+                models.sort(key=lambda m: m.name.lower())
+
+                return models
 
         except Exception as e:
             logger.error(f"Failed to get LM Studio models: {e}", exc_info=True)
@@ -315,126 +402,155 @@ class LMStudioService(AIService):
             book=book,
         )
 
-        # Create JSON input for all chapters
-        chapter_data = [{"id": idx, "title": text} for idx, text in enumerate(titles)]
-        user_message = f"Input data:\n{json.dumps(chapter_data)}"
-
         try:
-            # Get host and create client
             host = self._get_host()
             if not host:
-                raise ValueError("LM Studio host configuration is required")
+                raise ValueError("LM Studio server URL is required")
 
-            async with self._create_client(host) as client:
-                # Load the model
-                model = await client.llm.model(model_id)
-                model_info = await model.get_info()
+            headers = self._create_headers(self._get_api_key())
+            verify = not self._get_skip_ssl_verify()
 
-                is_gpt_oss = model_info.architecture == "gpt-oss"
+            total_chapters = len(titles)
 
-                # Initialize incremental parser for progress tracking
-                parser = IncrementalJSONParser()
-                total_chapters = len(titles)
+            base_payload = {
+                "model": model_id,
+                "messages": [
+                    {"role": "system", "content": system_prompt},
+                    {"role": "user", "content": f"Input data:\n{self._build_chapter_input(titles)}"},
+                ],
+                "stream": True,
+            }
 
-                # Stream the response for progress updates
-                stream_count = 0
-                content_received = ""
-                last_thinking_update = 0
+            structured_payload = {
+                **base_payload,
+                "response_format": CHAPTERS_RESPONSE_FORMAT,
+            }
 
-                # Combine system prompt and user message
-                combined_prompt = f"{system_prompt}\n\n{user_message}"
+            # Response from gpt-oss models is currently broken when using
+            # structured outputs. Seems to work well enough without it.
+            if "gpt-oss" in model_id.lower():
+                attempts = [base_payload]
+            else:
+                # Request structured output, but fall back to a plain request if
+                # the model rejects response_format.
+                attempts = [structured_payload, base_payload]
 
-                logger.info(f"LM Studio Combined prompt:\n{combined_prompt}")
+            content_received = ""
 
-                if is_gpt_oss:
-                    # Response from gpt-oss models is currently broken when using structured outputs. Seems to work well enough without it.
-                    response_format = None
-                else:
-                    response_format = {
-                        "type": "array",
-                        "items": {
-                            "type": "object",
-                            "properties": {
-                                "id": {"type": "number"},
-                                "title": {"type": ["string", "null"]},
-                            },
-                            "required": ["id", "title"],
-                        },
-                    }
+            async with httpx.AsyncClient(timeout=REQUEST_TIMEOUT, verify=verify) as client:
+                for attempt_index, payload in enumerate(attempts):
+                    is_last_attempt = attempt_index == len(attempts) - 1
+                    parser = IncrementalJSONParser()
+                    content_received = ""
+                    last_thinking_update = 0
 
-                async for chunk in await model.respond_stream(combined_prompt, response_format=response_format):
-                    stream_count += 1
-                    logger.debug(f"LM Studio Received chunk {stream_count}: {chunk}")
+                    async with client.stream(
+                        "POST",
+                        f"{host}/v1/chat/completions",
+                        headers=headers,
+                        json=payload,
+                    ) as response:
+                        if response.status_code != 200:
+                            await response.aread()
+                            error_text = response.text
+                            # Retry without response_format if that is what was rejected.
+                            if not is_last_attempt and response.status_code == 400:
+                                logger.warning(
+                                    f"LM Studio rejected structured output; retrying without it: {error_text}"
+                                )
+                                continue
+                            logger.error(f"LM Studio API error: {response.status_code} - {error_text}")
 
-                    # Handle thinking mode for models that support it
-                    if hasattr(chunk, "reasoning_type") and chunk.reasoning_type != "none":
-                        current_time = time.time()
-                        if current_time - last_thinking_update >= 1.0:  # Limit to once per second
-                            self._notify_progress(0, "Thinking…")
-                            last_thinking_update = current_time
-                        continue
+                            if response.status_code in (400, 404) and await self._model_not_loaded(
+                                client, host, headers, model_id
+                            ):
+                                raise Exception(
+                                    f'Model "{model_id}" is not loaded and JIT model loading appears to be '
+                                    "disabled in LM Studio - load the model in LM Studio (or enable JIT "
+                                    "model loading in its server settings) and try again"
+                                )
 
-                    if hasattr(chunk, "content") and chunk.content:
-                        content = chunk.content
-                        content_received += content
-                        logger.debug(f"LM Studio Content chunk: '{content}'")
-
-                        result = parser.feed(content)
-                        if result["new_chapters"]:
-                            progress_percent = result["total_parsed"] / total_chapters * 100
-                            self._notify_progress(
-                                progress_percent,
-                                f"Processed {result['total_parsed']}/{total_chapters} chapters",
+                            detail = self._extract_error_message(error_text)
+                            raise Exception(
+                                f"LM Studio API error: {response.status_code}" + (f" - {detail}" if detail else "")
                             )
 
-                if not content_received:
-                    logger.error("LM Studio No content received from streaming!")
+                        async for line in response.aiter_lines():
+                            if not line or not line.strip():
+                                continue
 
-                self._notify_progress(100, "Processing AI response…")
+                            line = line.strip()
+                            if not line.startswith("data: "):
+                                continue
 
-                # Parse the response
-                try:
-                    try:
-                        if is_gpt_oss:
-                            # For gpt-oss, take only content after "<|message|>"
-                            # Ideally this would be handled by LM Studio or with openai-harmony
-                            if "<|message|>" in content_received:
-                                content_received = content_received.split("<|message|>")[-1]
-                    except Exception as e:
-                        logger.debug(f"Could not get model info for architecture check: {e}")
+                            data_str = line[6:]  # Remove "data: " prefix
+                            if data_str == "[DONE]":
+                                break
 
-                    processed_chapters = json.loads(content_received)
+                            try:
+                                chunk = json.loads(data_str)
+                            except json.JSONDecodeError:
+                                continue
 
-                except json.JSONDecodeError as e:
-                    logger.error(f"LM Studio Failed to parse response as JSON: {e}")
-                    logger.error(f"LM Studio Raw response: {content_received}")
-                    raise
+                            if "choices" in chunk and len(chunk["choices"]) > 0:
+                                delta = chunk["choices"][0].get("delta", {})
 
-                # Convert to title list
-                chapters = [
-                    None if chapter.get("title") == "null" or chapter.get("title") is None else chapter.get("title")
-                    for chapter in processed_chapters
-                ]
+                                # Handle thinking mode for models that support it
+                                if delta.get("reasoning_content") or delta.get("reasoning"):
+                                    current_time = time.time()
+                                    if current_time - last_thinking_update >= 1.0:  # Limit to once per second
+                                        self._notify_progress(0, "Thinking…")
+                                        last_thinking_update = current_time
+                                    continue
 
-                valid_chapters = len([t for t in chapters if t])
+                                content = delta.get("content")
+                                if content:
+                                    content_received += content
 
-                self._notify_progress(100, f"Generated {valid_chapters} chapter titles")
+                                    result = parser.feed(content)
+                                    if result["new_chapters"]:
+                                        progress_percent = result["total_parsed"] / total_chapters * 100
+                                        self._notify_progress(
+                                            progress_percent,
+                                            f"Processed {result['total_parsed']}/{total_chapters} chapters",
+                                        )
 
-                return chapters
+                    # Stream completed successfully; no need to try further variants.
+                    break
 
-        except asyncio.TimeoutError as e:
+            if not content_received:
+                logger.error("LM Studio No content received from streaming!")
+
+            self._notify_progress(100, "Processing AI response…")
+
+            # Parse the response
+            try:
+                processed_chapters = self._extract_chapter_array(content_received)
+            except (json.JSONDecodeError, ValueError) as e:
+                logger.error(f"LM Studio Failed to parse response as JSON: {e}")
+                logger.error(f"LM Studio Raw response: {content_received}")
+                raise
+
+            # Convert to title list
+            chapters = [
+                None if chapter.get("title") == "null" or chapter.get("title") is None else chapter.get("title")
+                for chapter in processed_chapters
+            ]
+
+            valid_chapters = len([t for t in chapters if t])
+
+            self._notify_progress(100, f"Generated {valid_chapters} chapter titles")
+
+            return chapters
+
+        except httpx.TimeoutException as e:
             error_msg = f"LM Studio request timed out - server may be overloaded: {str(e)}"
             logger.error(f"LM Studio timeout error: {e}")
             self._notify_progress(0, error_msg)
             raise
-        except ConnectionError as e:
+        except httpx.RequestError as e:
             error_msg = f"Failed to connect to LM Studio - please ensure LM Studio is running and accessible: {str(e)}"
             logger.error(f"LM Studio connection error: {e}")
-            self._notify_progress(0, error_msg)
-            raise
-        except OSError as e:
-            error_msg = f"Network error connecting to LM Studio - check host and port: {str(e)}"
-            logger.error(f"LM Studio network error: {e}")
             self._notify_progress(0, error_msg)
             raise
         except json.JSONDecodeError as e:

--- a/backend/app/services/llm_providers/ollama_service.py
+++ b/backend/app/services/llm_providers/ollama_service.py
@@ -8,13 +8,16 @@ import ollama
 
 from app.models.abs import Book
 
-from .base import AIService, IncrementalJSONParser, ModelInfo, ProviderInfo
+from .base import CHAPTERS_SCHEMA, AIService, IncrementalJSONParser, ModelInfo, ProviderInfo, coerce_bool
 
 logger = logging.getLogger(__name__)
 
 
 class OllamaService(AIService):
     """Ollama implementation of AIService for local models"""
+
+    # Self-hosted: the user controls the model list, so always fetch it fresh.
+    CACHE_MODELS = False
 
     def __init__(self, progress_callback, **config):
         super().__init__(progress_callback, **config)
@@ -43,7 +46,17 @@ class OllamaService(AIService):
 
         return host
 
-    def _create_client(self, host=None):
+    def _get_skip_ssl_verify(self, config=None) -> bool:
+        """Get whether TLS certificate verification should be skipped."""
+        if config and "skip_ssl_verify" in config:
+            return coerce_bool(config["skip_ssl_verify"])
+
+        from ...core.config import get_app_config
+
+        app_config = get_app_config()
+        return app_config.llm.ollama.skip_ssl_verify
+
+    def _create_client(self, host=None, skip_ssl_verify=None):
         """Create an Ollama client with the given or current host"""
         if not host:
             host = self._get_host()
@@ -56,7 +69,11 @@ class OllamaService(AIService):
         if not parsed.netloc:
             raise ValueError(f"Invalid host URL: {host}")
 
-        return ollama.AsyncClient(host=host)
+        if skip_ssl_verify is None:
+            skip_ssl_verify = self._get_skip_ssl_verify()
+
+        # Extra kwargs are forwarded to the underlying httpx client
+        return ollama.AsyncClient(host=host, verify=not skip_ssl_verify)
 
     async def load_saved_config(self) -> dict:
         """Load saved configuration for Ollama provider"""
@@ -65,6 +82,7 @@ class OllamaService(AIService):
         config = get_app_config()
         return {
             "host": config.llm.ollama.host or "",
+            "skip_ssl_verify": config.llm.ollama.skip_ssl_verify,
             "enabled": config.llm.ollama.enabled,
             "validated": config.llm.ollama.validated,
             "validation_status": config.llm.ollama.validation_status,
@@ -89,6 +107,7 @@ class OllamaService(AIService):
             # Save configuration
             provider_config = LLMProviderConfig(
                 host=host,
+                skip_ssl_verify=self._get_skip_ssl_verify(config),
                 enabled=config.get("enabled", True),
                 validated=valid,
                 last_validated=datetime.now(timezone.utc) if valid else None,
@@ -154,7 +173,9 @@ class OllamaService(AIService):
         new_host = self._get_host(new_config) or ""
         saved_host = self._saved_config.get("host", "")
 
-        return new_host != saved_host
+        return new_host != saved_host or self._get_skip_ssl_verify(new_config) != coerce_bool(
+            self._saved_config.get("skip_ssl_verify", False)
+        )
 
     def get_provider_state(self) -> ProviderInfo:
         """Get current provider state including enabled/configured status"""
@@ -194,11 +215,18 @@ class OllamaService(AIService):
                 {
                     "name": "host",
                     "type": "text",
-                    "label": "Ollama Host URL",
-                    "placeholder": "http://localhost:11434",
-                    "required": False,
+                    "label": "Server URL",
+                    "placeholder": "Server URL (e.g. http://localhost:11434)",
+                    "required": True,
                     "help_url": "https://github.com/ollama/ollama/blob/66fb8575ced090a969c9529c88ee57a8df1259c2/docs/faq.md#how-can-i-expose-ollama-on-my-network",
-                }
+                },
+                {
+                    "name": "skip_ssl_verify",
+                    "type": "checkbox",
+                    "label": "Skip SSL certificate verification",
+                    "help_text": "Allows HTTPS servers with self-signed certificates. Only enable this for servers you trust.",
+                    "required": False,
+                },
             ],
             is_available=True,
         )
@@ -214,7 +242,7 @@ class OllamaService(AIService):
 
         try:
             # Create client using helper method
-            client = self._create_client(host)
+            client = self._create_client(host, self._get_skip_ssl_verify(config))
 
             # Add 5-second timeout to the validation
             import asyncio
@@ -313,8 +341,7 @@ class OllamaService(AIService):
         )
 
         # Create JSON input for all chapters
-        chapter_data = [{"id": idx, "title": text} for idx, text in enumerate(titles)]
-        user_message = f"Input data:\n{json.dumps(chapter_data)}"
+        user_message = f"Input data:\n{self._build_chapter_input(titles)}"
 
         try:
             # Get host and create client
@@ -348,17 +375,7 @@ class OllamaService(AIService):
                 # Response from gpt-oss models is currently broken when using structured outputs. Seems to work well enough without it.
                 format = None
             else:
-                format = {
-                    "type": "array",
-                    "items": {
-                        "type": "object",
-                        "properties": {
-                            "id": {"type": "number"},
-                            "title": {"type": ["string", "null"]},
-                        },
-                        "required": ["id", "title"],
-                    },
-                }
+                format = CHAPTERS_SCHEMA
 
             async for chunk in await processing_client.generate(
                 model=model_id,
@@ -395,9 +412,9 @@ class OllamaService(AIService):
 
             # Parse the response
             try:
-                processed_chapters = json.loads(content_received)
+                processed_chapters = self._extract_chapter_array(content_received)
 
-            except json.JSONDecodeError as e:
+            except (json.JSONDecodeError, ValueError) as e:
                 logger.error(f"Ollama Failed to parse Ollama response as JSON: {e}")
                 logger.error(f"Ollama Raw response: {content_received}")
                 raise

--- a/backend/app/services/llm_providers/openai_compatible_service.py
+++ b/backend/app/services/llm_providers/openai_compatible_service.py
@@ -1,14 +1,21 @@
+import asyncio
 import json
 import logging
+import time
 from typing import List, Optional
 
 import httpx
 
 from app.models.abs import Book
 
-from .base import AIService, IncrementalJSONParser, ModelInfo, ProviderInfo
+from .base import CHAPTERS_RESPONSE_FORMAT, AIService, IncrementalJSONParser, ModelInfo, ProviderInfo, coerce_bool
 
 logger = logging.getLogger(__name__)
+
+# How long to wait for the first streamed token before telling the user the
+# endpoint may still be loading the model. There is no standard "loading"
+# signal in the OpenAI API surface, so first-token latency is the best proxy.
+FIRST_TOKEN_WATCHDOG_SECONDS = 5.0
 
 
 class OpenAICompatibleService(AIService):
@@ -18,6 +25,9 @@ class OpenAICompatibleService(AIService):
     discovery and ``POST {base_url}/chat/completions`` for generation. The base
     URL and (optional) API key are supplied by the user via the frontend.
     """
+
+    # Self-hosted: the user controls the model list, so always fetch it fresh.
+    CACHE_MODELS = False
 
     def __init__(self, progress_callback, **config):
         super().__init__(progress_callback, **config)
@@ -52,6 +62,16 @@ class OpenAICompatibleService(AIService):
         app_config = get_app_config()
         return app_config.llm.openai_compatible.api_key
 
+    def _get_skip_ssl_verify(self, config=None) -> bool:
+        """Get whether TLS certificate verification should be skipped."""
+        if config and "skip_ssl_verify" in config:
+            return coerce_bool(config["skip_ssl_verify"])
+
+        from ...core.config import get_app_config
+
+        app_config = get_app_config()
+        return app_config.llm.openai_compatible.skip_ssl_verify
+
     def _create_headers(self, api_key: str = "") -> dict:
         """Build request headers, including auth only when a key is set."""
         headers = {"Content-Type": "application/json"}
@@ -59,23 +79,14 @@ class OpenAICompatibleService(AIService):
             headers["Authorization"] = f"Bearer {api_key}"
         return headers
 
-    @staticmethod
-    def _strip_code_fences(text: str) -> str:
-        """Strip Markdown code fences some models wrap JSON in despite instructions.
+    def _start_first_token_watchdog(self) -> asyncio.Task:
+        """Update the status if the endpoint is slow to produce its first token."""
 
-        Handles blocks like ``` ```json ... ``` ``` by dropping the opening fence
-        line (with any language hint) and the closing fence. Returns the input
-        unchanged when no leading fence is present.
-        """
-        stripped = text.strip()
-        if not stripped.startswith("```"):
-            return stripped
+        async def watchdog():
+            await asyncio.sleep(FIRST_TOKEN_WATCHDOG_SECONDS)
+            self._notify_progress(0, "Waiting for a response - the endpoint may be loading the model…")
 
-        lines = stripped.splitlines()
-        lines = lines[1:]  # Drop the opening fence (e.g. ``` or ```json).
-        if lines and lines[-1].strip().startswith("```"):
-            lines = lines[:-1]  # Drop the closing fence.
-        return "\n".join(lines).strip()
+        return asyncio.create_task(watchdog())
 
     async def load_saved_config(self) -> dict:
         """Load saved configuration for the OpenAI-compatible provider."""
@@ -85,6 +96,7 @@ class OpenAICompatibleService(AIService):
         return {
             "base_url": config.llm.openai_compatible.base_url,
             "api_key": config.llm.openai_compatible.api_key,
+            "skip_ssl_verify": config.llm.openai_compatible.skip_ssl_verify,
             "enabled": config.llm.openai_compatible.enabled,
             "validated": config.llm.openai_compatible.validated,
             "validation_status": config.llm.openai_compatible.validation_status,
@@ -104,9 +116,15 @@ class OpenAICompatibleService(AIService):
 
             valid, message = await self.validate_config(**config)
 
+            # The frontend omits the api_key field when it is unchanged (it only
+            # ever sees a masked value), so fall back to the saved key rather
+            # than wiping it. An explicit empty string still clears it.
+            api_key = config["api_key"] if "api_key" in config else self._get_api_key()
+
             provider_config = LLMProviderConfig(
                 base_url=base_url,
-                api_key=config.get("api_key", ""),
+                api_key=api_key,
+                skip_ssl_verify=self._get_skip_ssl_verify(config),
                 enabled=config.get("enabled", True),
                 validated=valid,
                 last_validated=datetime.now(timezone.utc) if valid else None,
@@ -154,8 +172,6 @@ class OpenAICompatibleService(AIService):
         """Check if configuration has changed from saved state."""
         if not self._saved_config:
             try:
-                import asyncio
-
                 saved = asyncio.run(self.load_saved_config())
                 self._saved_config = saved
             except Exception:
@@ -164,7 +180,11 @@ class OpenAICompatibleService(AIService):
         new_base_url = self._get_base_url(new_config) or ""
         saved_base_url = (self._saved_config.get("base_url") or "").rstrip("/")
 
-        return new_base_url != saved_base_url or new_config.get("api_key", "") != self._saved_config.get("api_key", "")
+        return (
+            new_base_url != saved_base_url
+            or new_config.get("api_key", "") != self._saved_config.get("api_key", "")
+            or self._get_skip_ssl_verify(new_config) != coerce_bool(self._saved_config.get("skip_ssl_verify", False))
+        )
 
     def get_provider_state(self) -> ProviderInfo:
         """Get current provider state including enabled/configured status."""
@@ -198,22 +218,29 @@ class OpenAICompatibleService(AIService):
         return ProviderInfo(
             id="openai_compatible",
             name="OpenAI-Compatible",
-            description="Connect to any OpenAI-compatible endpoint such as LiteLLM, vLLM, or another gateway. "
-            "The Base URL should point at the API root that serves /models and /chat/completions "
-            "(commonly ending in /v1).",
+            description="Connect to any OpenAI-compatible endpoint such as LiteLLM, vLLM, or another gateway.",
+            instructions="The Base URL is the API root serving <b>/models</b> and <b>/chat/completions</b>, "
+            "usually ending in <b>/v1</b>.",
             setup_fields=[
                 {
                     "name": "base_url",
                     "type": "text",
                     "label": "Base URL",
-                    "placeholder": "http://litellm.local:4000/v1",
+                    "placeholder": "Base URL (e.g. http://litellm.local:4000/v1)",
                     "required": True,
                 },
                 {
                     "name": "api_key",
                     "type": "password",
                     "label": "API Key",
-                    "placeholder": "Optional (leave blank if not required)",
+                    "placeholder": "API Key (leave blank if not required)",
+                    "required": False,
+                },
+                {
+                    "name": "skip_ssl_verify",
+                    "type": "checkbox",
+                    "label": "Skip SSL certificate verification",
+                    "help_text": "Allows HTTPS servers with self-signed certificates. Only enable this for servers you trust.",
                     "required": False,
                 },
             ],
@@ -229,7 +256,8 @@ class OpenAICompatibleService(AIService):
 
         try:
             headers = self._create_headers(api_key)
-            async with httpx.AsyncClient(timeout=10.0) as client:
+            verify = not self._get_skip_ssl_verify(config)
+            async with httpx.AsyncClient(timeout=10.0, verify=verify) as client:
                 response = await client.get(f"{base_url}/models", headers=headers)
 
                 if response.status_code == 200:
@@ -258,7 +286,7 @@ class OpenAICompatibleService(AIService):
             api_key = self._get_api_key()
             headers = self._create_headers(api_key)
 
-            async with httpx.AsyncClient(timeout=30.0) as client:
+            async with httpx.AsyncClient(timeout=30.0, verify=not self._get_skip_ssl_verify()) as client:
                 response = await client.get(f"{base_url}/models", headers=headers)
 
                 if response.status_code != 200:
@@ -317,8 +345,6 @@ class OpenAICompatibleService(AIService):
             book=book,
         )
 
-        chapter_data = [{"id": idx, "title": text} for idx, text in enumerate(titles)]
-
         try:
             base_url = self._get_base_url()
             if not base_url:
@@ -334,66 +360,89 @@ class OpenAICompatibleService(AIService):
                 "model": model_id,
                 "messages": [
                     {"role": "system", "content": system_prompt},
-                    {"role": "user", "content": json.dumps(chapter_data)},
+                    {"role": "user", "content": self._build_chapter_input(titles)},
                 ],
                 "stream": True,
             }
 
-            # Request JSON output, but fall back to a plain request if the
-            # endpoint/model rejects response_format. A generic OpenAI-compatible
-            # gateway fronts many backends, not all of which support it.
+            # Try progressively less constrained output modes. The strict schema
+            # can express the array shape the prompt asks for; json_object alone
+            # cannot, so it is only a fallback for gateways that reject schemas.
+            # A generic OpenAI-compatible gateway fronts many backends, and any
+            # mode may be rejected outright (HTTP 400) or accepted but mangled
+            # (e.g. Ollama's json_object grammar ends generation after a single
+            # object), so both outcomes advance to the next attempt.
             attempts = [
+                {**base_payload, "response_format": CHAPTERS_RESPONSE_FORMAT},
                 {**base_payload, "response_format": {"type": "json_object"}},
                 base_payload,
             ]
 
             content_received = ""
+            processed_chapters = []
 
-            async with httpx.AsyncClient(timeout=120.0) as client:
+            async with httpx.AsyncClient(timeout=120.0, verify=not self._get_skip_ssl_verify()) as client:
                 for attempt_index, payload in enumerate(attempts):
                     is_last_attempt = attempt_index == len(attempts) - 1
                     parser = IncrementalJSONParser()
                     content_received = ""
+                    last_thinking_update = 0
 
-                    async with client.stream(
-                        "POST",
-                        f"{base_url}/chat/completions",
-                        headers=headers,
-                        json=payload,
-                        timeout=60.0,
-                    ) as response:
-                        if response.status_code != 200:
-                            await response.aread()
-                            error_text = response.text
-                            # Retry without response_format if that is what was rejected.
-                            if not is_last_attempt and response.status_code == 400 and "response_format" in error_text:
-                                logger.warning("Endpoint rejected response_format; retrying without it")
-                                continue
-                            logger.error(f"OpenAI-compatible API error: {response.status_code} - {error_text}")
-                            raise Exception(f"OpenAI-compatible API error: {response.status_code}")
+                    watchdog = self._start_first_token_watchdog()
+                    try:
+                        async with client.stream(
+                            "POST",
+                            f"{base_url}/chat/completions",
+                            headers=headers,
+                            json=payload,
+                            timeout=60.0,
+                        ) as response:
+                            if response.status_code != 200:
+                                await response.aread()
+                                error_text = response.text
+                                # Retry with a less constrained mode if the format was rejected.
+                                format_rejected = response.status_code == 400 and any(
+                                    term in error_text for term in ("response_format", "json_schema", "json_object")
+                                )
+                                if not is_last_attempt and format_rejected:
+                                    logger.warning("Endpoint rejected the response format; retrying with a simpler one")
+                                    continue
+                                logger.error(f"OpenAI-compatible API error: {response.status_code} - {error_text}")
+                                raise Exception(f"OpenAI-compatible API error: {response.status_code}")
 
-                        async for line in response.aiter_lines():
-                            if not line or not line.strip():
-                                continue
+                            async for line in response.aiter_lines():
+                                if not line or not line.strip():
+                                    continue
 
-                            line = line.strip()
-                            if not line.startswith("data: "):
-                                continue
+                                line = line.strip()
+                                if not line.startswith("data: "):
+                                    continue
 
-                            data_str = line[6:]  # Remove "data: " prefix
-                            if data_str == "[DONE]":
-                                break
+                                data_str = line[6:]  # Remove "data: " prefix
+                                if data_str == "[DONE]":
+                                    break
 
-                            try:
-                                chunk = json.loads(data_str)
-                            except json.JSONDecodeError:
-                                continue
+                                try:
+                                    chunk = json.loads(data_str)
+                                except json.JSONDecodeError:
+                                    continue
 
-                            if "choices" in chunk and len(chunk["choices"]) > 0:
-                                choice = chunk["choices"][0]
+                                watchdog.cancel()
 
-                                if "delta" in choice and "content" in choice["delta"]:
-                                    content = choice["delta"]["content"]
+                                if "choices" in chunk and len(chunk["choices"]) > 0:
+                                    delta = chunk["choices"][0].get("delta", {})
+
+                                    # Reasoning models stream thinking separately:
+                                    # reasoning_content (DeepSeek/vLLM/LiteLLM/LM Studio)
+                                    # or reasoning (OpenRouter).
+                                    if delta.get("reasoning_content") or delta.get("reasoning"):
+                                        current_time = time.time()
+                                        if current_time - last_thinking_update >= 1.0:  # Limit to once per second
+                                            self._notify_progress(0, "Thinking…")
+                                            last_thinking_update = current_time
+                                        continue
+
+                                    content = delta.get("content")
                                     if content:
                                         content_received += content
 
@@ -404,33 +453,26 @@ class OpenAICompatibleService(AIService):
                                                 progress_percent,
                                                 f"Processed {result['total_parsed']}/{total_chapters} chapters",
                                             )
+                    finally:
+                        watchdog.cancel()
 
-                    # Stream completed successfully; no need to try further variants.
+                    self._notify_progress(100, "Processing AI response…")
+
+                    try:
+                        processed_chapters = self._extract_chapter_array(content_received)
+                    except (json.JSONDecodeError, ValueError) as e:
+                        # A backend can accept a response_format yet still produce
+                        # the wrong shape (e.g. Ollama's json_object mode returns a
+                        # single object). Fall back to the next attempt.
+                        if not is_last_attempt:
+                            logger.warning(f"Could not parse response ({e}); retrying with a simpler response format")
+                            continue
+                        logger.error(f"Failed to parse OpenAI-compatible response: {e}")
+                        logger.error(f"Raw response: {content_received}")
+                        raise
+
+                    # Stream parsed successfully; no need to try further variants.
                     break
-
-            self._notify_progress(100, "Processing AI response…")
-
-            try:
-                response_data = json.loads(self._strip_code_fences(content_received))
-
-                if isinstance(response_data, list):
-                    processed_chapters = response_data
-                elif isinstance(response_data, dict) and "chapters" in response_data:
-                    processed_chapters = response_data["chapters"]
-                else:
-                    processed_chapters = []
-                    for value in response_data.values() if isinstance(response_data, dict) else []:
-                        if isinstance(value, list):
-                            processed_chapters = value
-                            break
-
-                if not processed_chapters:
-                    raise ValueError("No chapter array found in response")
-
-            except (json.JSONDecodeError, ValueError) as e:
-                logger.error(f"Failed to parse OpenAI-compatible response: {e}")
-                logger.error(f"Raw response: {content_received}")
-                raise
 
             chapters = []
             for chapter in processed_chapters:

--- a/backend/app/services/llm_providers/openai_service.py
+++ b/backend/app/services/llm_providers/openai_service.py
@@ -335,7 +335,6 @@ class OpenAIService(AIService):
         )
 
         # Create JSON input for all chapters
-        chapter_data = [{"id": idx, "title": text} for idx, text in enumerate(titles)]
 
         try:
             client = self._create_client()
@@ -347,7 +346,7 @@ class OpenAIService(AIService):
         try:
             # Use structured output parsing
             system_message = EasyInputMessageParam(role="system", content=system_prompt)
-            user_message = EasyInputMessageParam(role="user", content=json.dumps(chapter_data))
+            user_message = EasyInputMessageParam(role="user", content=self._build_chapter_input(titles))
 
             # Initialize incremental parser for progress tracking
             parser = IncrementalJSONParser()

--- a/backend/app/services/llm_providers/openrouter_service.py
+++ b/backend/app/services/llm_providers/openrouter_service.py
@@ -1,13 +1,13 @@
 import json
 import logging
 import time
-from typing import List, Optional
+from typing import Any, Dict, List, Optional
 
 import httpx
 
 from app.models.abs import Book
 
-from .base import AIService, IncrementalJSONParser, ModelInfo, ProviderInfo
+from .base import CHAPTERS_RESPONSE_FORMAT, AIService, IncrementalJSONParser, ModelInfo, ProviderInfo
 
 logger = logging.getLogger(__name__)
 
@@ -274,8 +274,6 @@ class OpenRouterService(AIService):
             book=book,
         )
 
-        chapter_data = [{"id": idx, "title": text} for idx, text in enumerate(titles)]
-
         try:
             api_key = self._get_api_key()
             if not api_key:
@@ -285,104 +283,119 @@ class OpenRouterService(AIService):
 
             headers = self._create_headers(api_key)
 
-            parser = IncrementalJSONParser()
             total_chapters = len(titles)
 
             is_thinking_model = any(term in model_id.lower() for term in ["reasoning", "thinking"])
 
-            payload = {
+            base_payload: Dict[str, Any] = {
                 "model": model_id,
                 "messages": [
                     {"role": "system", "content": system_prompt},
-                    {"role": "user", "content": json.dumps(chapter_data)},
+                    {"role": "user", "content": self._build_chapter_input(titles)},
                 ],
                 "stream": True,
-                "response_format": {"type": "json_object"},
             }
 
             if is_thinking_model:
-                payload["reasoning"] = {"max_tokens": 1024}
+                base_payload["reasoning"] = {"max_tokens": 1024}
+
+            # Try progressively less constrained output modes. The strict schema
+            # can express the array shape the prompt asks for; json_object alone
+            # cannot, so it is only a fallback for models that reject schemas.
+            # A mode may be rejected outright (HTTP 400) or accepted but produce
+            # the wrong shape, so both outcomes advance to the next attempt.
+            attempts = [
+                {**base_payload, "response_format": CHAPTERS_RESPONSE_FORMAT},
+                {**base_payload, "response_format": {"type": "json_object"}},
+                base_payload,
+            ]
 
             content_received = ""
-            last_thinking_update = 0
+            processed_chapters = []
 
             async with httpx.AsyncClient(timeout=120.0) as client:
-                async with client.stream(
-                    "POST",
-                    "https://openrouter.ai/api/v1/chat/completions",
-                    headers=headers,
-                    json=payload,
-                    timeout=60.0,
-                ) as response:
-                    if response.status_code != 200:
-                        await response.aread()
-                        error_text = response.text
-                        logger.error(f"OpenRouter API error: {response.status_code} - {error_text}")
-                        raise Exception(f"OpenRouter API error: {response.status_code}")
+                for attempt_index, payload in enumerate(attempts):
+                    is_last_attempt = attempt_index == len(attempts) - 1
+                    parser = IncrementalJSONParser()
+                    content_received = ""
+                    last_thinking_update = 0
 
-                    async for line in response.aiter_lines():
-                        if not line or not line.strip():
-                            continue
+                    async with client.stream(
+                        "POST",
+                        "https://openrouter.ai/api/v1/chat/completions",
+                        headers=headers,
+                        json=payload,
+                        timeout=60.0,
+                    ) as response:
+                        if response.status_code != 200:
+                            await response.aread()
+                            error_text = response.text
+                            # Retry with a less constrained mode if the format was rejected.
+                            format_rejected = response.status_code == 400 and any(
+                                term in error_text for term in ("response_format", "json_schema", "json_object")
+                            )
+                            if not is_last_attempt and format_rejected:
+                                logger.warning("OpenRouter rejected the response format; retrying with a simpler one")
+                                continue
+                            logger.error(f"OpenRouter API error: {response.status_code} - {error_text}")
+                            raise Exception(f"OpenRouter API error: {response.status_code}")
 
-                        line = line.strip()
-                        if not line.startswith("data: "):
-                            continue
-
-                        data_str = line[6:]  # Remove "data: " prefix
-                        if data_str == "[DONE]":
-                            break
-
-                        try:
-                            chunk = json.loads(data_str)
-                        except json.JSONDecodeError:
-                            continue
-
-                        if "choices" in chunk and len(chunk["choices"]) > 0:
-                            choice = chunk["choices"][0]
-
-                            if "delta" in choice and choice["delta"].get("reasoning"):
-                                current_time = time.time()
-                                if current_time - last_thinking_update >= 1.0:
-                                    self._notify_progress(0, "Thinking…")
-                                    last_thinking_update = current_time
+                        async for line in response.aiter_lines():
+                            if not line or not line.strip():
                                 continue
 
-                            if "delta" in choice and "content" in choice["delta"]:
-                                content = choice["delta"]["content"]
-                                if content:
-                                    content_received += content
+                            line = line.strip()
+                            if not line.startswith("data: "):
+                                continue
 
-                                    result = parser.feed(content)
-                                    if result["new_chapters"]:
-                                        progress_percent = result["total_parsed"] / total_chapters * 100
-                                        self._notify_progress(
-                                            progress_percent,
-                                            f"Processed {result['total_parsed']}/{total_chapters} chapters",
-                                        )
+                            data_str = line[6:]  # Remove "data: " prefix
+                            if data_str == "[DONE]":
+                                break
 
-            self._notify_progress(100, "Processing AI response…")
+                            try:
+                                chunk = json.loads(data_str)
+                            except json.JSONDecodeError:
+                                continue
 
-            try:
-                response_data = json.loads(content_received)
+                            if "choices" in chunk and len(chunk["choices"]) > 0:
+                                choice = chunk["choices"][0]
 
-                if isinstance(response_data, list):
-                    processed_chapters = response_data
-                elif isinstance(response_data, dict) and "chapters" in response_data:
-                    processed_chapters = response_data["chapters"]
-                else:
-                    processed_chapters = []
-                    for value in response_data.values() if isinstance(response_data, dict) else []:
-                        if isinstance(value, list):
-                            processed_chapters = value
-                            break
+                                if "delta" in choice and choice["delta"].get("reasoning"):
+                                    current_time = time.time()
+                                    if current_time - last_thinking_update >= 1.0:
+                                        self._notify_progress(0, "Thinking…")
+                                        last_thinking_update = current_time
+                                    continue
 
-                if not processed_chapters:
-                    raise ValueError("No chapter array found in response")
+                                if "delta" in choice and "content" in choice["delta"]:
+                                    content = choice["delta"]["content"]
+                                    if content:
+                                        content_received += content
 
-            except (json.JSONDecodeError, ValueError) as e:
-                logger.error(f"Failed to parse OpenRouter response: {e}")
-                logger.error(f"Raw response: {content_received}")
-                raise
+                                        result = parser.feed(content)
+                                        if result["new_chapters"]:
+                                            progress_percent = result["total_parsed"] / total_chapters * 100
+                                            self._notify_progress(
+                                                progress_percent,
+                                                f"Processed {result['total_parsed']}/{total_chapters} chapters",
+                                            )
+
+                    self._notify_progress(100, "Processing AI response…")
+
+                    try:
+                        processed_chapters = self._extract_chapter_array(content_received)
+                    except (json.JSONDecodeError, ValueError) as e:
+                        # A model can accept a response_format yet still produce
+                        # the wrong shape. Fall back to the next attempt.
+                        if not is_last_attempt:
+                            logger.warning(f"Could not parse response ({e}); retrying with a simpler response format")
+                            continue
+                        logger.error(f"Failed to parse OpenRouter response: {e}")
+                        logger.error(f"Raw response: {content_received}")
+                        raise
+
+                    # Stream parsed successfully; no need to try further variants.
+                    break
 
             chapters = []
             for chapter in processed_chapters:

--- a/backend/app/services/llm_providers/registry.py
+++ b/backend/app/services/llm_providers/registry.py
@@ -162,19 +162,23 @@ class ProviderRegistry:
 
     async def get_provider_models(self, provider_id: str, **config) -> List[ModelInfo]:
         """Get available models for a provider (cached per provider+config)"""
+        provider_class = self.get_provider_class(provider_id)
+        cacheable = provider_class.CACHE_MODELS if provider_class else True
+
         cache_key = (provider_id, tuple(sorted(config.items())))
-        cached = self._model_cache.get(cache_key)
-        if cached:
-            fetched_at, models = cached
-            if time.monotonic() - fetched_at < MODEL_CACHE_TTL_SECONDS:
-                return list(models)
+        if cacheable:
+            cached = self._model_cache.get(cache_key)
+            if cached:
+                fetched_at, models = cached
+                if time.monotonic() - fetched_at < MODEL_CACHE_TTL_SECONDS:
+                    return list(models)
 
         try:
             provider = self.create_provider(provider_id, _noop_progress, **config)
             if provider:
                 models = await provider.get_available_models()
                 # Providers signal failure with an empty list — don't cache it.
-                if models:
+                if cacheable and models:
                     self._model_cache[cache_key] = (time.monotonic(), models)
                 return models
             return []

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -28,7 +28,6 @@ dependencies = [
     "ollama>=0.5.1",
     "google-genai[aiohttp]>=1.65.0",
     "anthropic>=0.76.0",
-    "lmstudio==1.4.1",
     "pywhispercpp>=1.3.3",
     "github-copilot-sdk>=1.0.5,<2",
     "python-multipart==0.0.24",

--- a/backend/tests/llm_providers/test_lm_studio_service.py
+++ b/backend/tests/llm_providers/test_lm_studio_service.py
@@ -1,0 +1,244 @@
+"""Tests for the LM Studio provider.
+
+The provider talks to LM Studio's REST API over HTTP(S) so it can support
+optional API token authentication and self-signed certificates. These tests
+exercise the HTTP surface (model discovery, validation, and the streaming
+chat-completions call) against a mocked endpoint.
+"""
+
+import json
+
+import httpx
+import pytest
+
+from app.core import config as C
+from app.services.llm_providers.lm_studio_service import LMStudioService
+
+HOST = "http://lmstudio.test:1234"
+
+
+@pytest.fixture(autouse=True)
+def isolated_config(monkeypatch):
+    """Use an isolated default config for tests."""
+    app_cfg = C.AppConfig()
+    monkeypatch.setattr(C, "_app_config", app_cfg)
+    return app_cfg
+
+
+@pytest.fixture
+def configured(isolated_config):
+    """Point the isolated config at the mocked endpoint."""
+    isolated_config.llm.lm_studio.host = HOST
+    isolated_config.llm.lm_studio.api_key = "lm-test-token"
+    return isolated_config
+
+
+def make_service():
+    return LMStudioService(lambda *a, **k: None)
+
+
+def sse(obj) -> bytes:
+    """Encode a chat-completions object as a minimal SSE stream."""
+    delta = {"choices": [{"delta": {"content": json.dumps(obj)}}]}
+    return ("data: " + json.dumps(delta) + "\n\n" + "data: [DONE]\n\n").encode()
+
+
+def test_host_normalization():
+    svc = make_service()
+    assert svc._get_host({"host": "localhost:1234"}) == "http://localhost:1234"
+    assert svc._get_host({"host": "https://lms.example.com/"}) == "https://lms.example.com"
+    assert svc._get_host({"host": ""}) is None
+
+
+def test_skip_ssl_verify_coercion(configured):
+    svc = make_service()
+    assert svc._get_skip_ssl_verify({"skip_ssl_verify": True}) is True
+    assert svc._get_skip_ssl_verify({"skip_ssl_verify": "false"}) is False
+    # Falls back to the saved configuration when not in the passed config.
+    configured.llm.lm_studio.skip_ssl_verify = True
+    assert svc._get_skip_ssl_verify({}) is True
+
+
+async def test_validate_config_missing_host():
+    ok, msg = await make_service().validate_config(host="")
+    assert ok is False
+    assert "server URL" in msg
+
+
+async def test_validate_config_success_sends_token(httpx_mock):
+    httpx_mock.add_response(url=f"{HOST}/v1/models", json={"data": []})
+    ok, _ = await make_service().validate_config(host=HOST, api_key="lm-test-token")
+    assert ok is True
+    assert httpx_mock.get_request().headers["Authorization"] == "Bearer lm-test-token"
+
+
+async def test_validate_config_auth_failure(httpx_mock):
+    httpx_mock.add_response(url=f"{HOST}/v1/models", status_code=401)
+    ok, msg = await make_service().validate_config(host=HOST, api_key="bad")
+    assert ok is False
+    assert "API token" in msg
+
+
+async def test_get_available_models_filters_and_sorts(configured, httpx_mock):
+    httpx_mock.add_response(
+        url=f"{HOST}/api/v0/models",
+        json={
+            "data": [
+                {"id": "qwen3-8b", "type": "llm", "arch": "qwen3", "max_context_length": 32768},
+                {"id": "text-embedding", "type": "embeddings"},
+                {"id": "Llama-3.1-8B", "type": "llm"},
+                {"id": ""},
+            ]
+        },
+    )
+    models = await make_service().get_available_models()
+    # Sorted case-insensitively; embeddings and empty ids are dropped.
+    assert [m.id for m in models] == ["Llama-3.1-8B", "qwen3-8b"]
+    assert models[1].context_length == 32768
+
+
+async def test_get_available_models_falls_back_to_v1(configured, httpx_mock):
+    httpx_mock.add_response(url=f"{HOST}/api/v0/models", status_code=404)
+    httpx_mock.add_response(url=f"{HOST}/v1/models", json={"data": [{"id": "some-model"}]})
+    models = await make_service().get_available_models()
+    assert [m.id for m in models] == ["some-model"]
+
+
+async def test_process_chapter_titles_happy_path(configured, httpx_mock):
+    obj = [{"id": 0, "title": "Chapter 1"}, {"id": 1, "title": None}]
+    httpx_mock.add_response(url=f"{HOST}/v1/chat/completions", content=sse(obj))
+
+    result = await make_service().process_chapter_titles(["chapter one", "noise"], "qwen3-8b")
+    assert result == ["Chapter 1", None]
+
+    request = httpx_mock.get_request()
+    payload = json.loads(request.content)
+    assert payload["response_format"]["type"] == "json_schema"
+    assert request.headers["Authorization"] == "Bearer lm-test-token"
+    # The input is wrapped in the same {"chapters": [...]} shape the prompt describes.
+    user_content = json.loads(payload["messages"][1]["content"].removeprefix("Input data:\n"))
+    assert user_content == {"chapters": [{"id": 0, "title": "chapter one"}, {"id": 1, "title": "noise"}]}
+
+
+async def test_process_chapter_titles_falls_back_without_response_format(configured, httpx_mock):
+    # First attempt: backend rejects structured output.
+    httpx_mock.add_response(
+        url=f"{HOST}/v1/chat/completions",
+        status_code=400,
+        json={"error": "response_format is not supported by this model"},
+    )
+    # Second attempt: succeeds without it.
+    obj = [{"id": 0, "title": "Chapter 1"}]
+    httpx_mock.add_response(url=f"{HOST}/v1/chat/completions", content=sse(obj))
+
+    result = await make_service().process_chapter_titles(["chapter one"], "some-model")
+    assert result == ["Chapter 1"]
+
+    requests = httpx_mock.get_requests()
+    assert len(requests) == 2
+    assert "response_format" in json.loads(requests[0].content)
+    assert "response_format" not in json.loads(requests[1].content)
+
+
+async def test_process_chapter_titles_gpt_oss_skips_structured_output(configured, httpx_mock):
+    obj = [{"id": 0, "title": "Chapter 1"}]
+    httpx_mock.add_response(url=f"{HOST}/v1/chat/completions", content=sse(obj))
+
+    result = await make_service().process_chapter_titles(["chapter one"], "openai/gpt-oss-20b")
+    assert result == ["Chapter 1"]
+    assert "response_format" not in json.loads(httpx_mock.get_request().content)
+
+
+async def test_process_chapter_titles_empty_input():
+    assert await make_service().process_chapter_titles([], "qwen3-8b") == []
+
+
+async def test_validate_config_includes_server_error_detail(httpx_mock):
+    httpx_mock.add_response(
+        url=f"{HOST}/v1/models",
+        status_code=500,
+        json={"error": {"message": "Something exploded"}},
+    )
+    ok, msg = await make_service().validate_config(host=HOST)
+    assert ok is False
+    assert "HTTP 500" in msg
+    assert "Something exploded" in msg
+
+
+async def test_process_error_includes_server_message(configured, httpx_mock):
+    # gpt-oss id keeps this to a single (unstructured) attempt.
+    httpx_mock.add_response(
+        url=f"{HOST}/v1/chat/completions",
+        status_code=400,
+        json={"error": {"message": "Model crashed"}},
+    )
+    # The not-loaded diagnosis runs for 400s; the model is loaded, so the
+    # server's own message is surfaced instead.
+    httpx_mock.add_response(
+        url=f"{HOST}/api/v0/models",
+        json={"data": [{"id": "openai/gpt-oss-20b", "type": "llm", "state": "loaded"}]},
+    )
+
+    with pytest.raises(Exception, match="Model crashed"):
+        await make_service().process_chapter_titles(["chapter one"], "openai/gpt-oss-20b")
+
+
+async def test_process_error_diagnoses_unloaded_model(configured, httpx_mock):
+    httpx_mock.add_response(
+        url=f"{HOST}/v1/chat/completions",
+        status_code=404,
+        json={"error": "model not found"},
+    )
+    httpx_mock.add_response(
+        url=f"{HOST}/api/v0/models",
+        json={"data": [{"id": "qwen3-8b", "type": "llm", "state": "not-loaded"}]},
+    )
+
+    with pytest.raises(Exception, match="JIT model loading"):
+        await make_service().process_chapter_titles(["chapter one"], "qwen3-8b")
+
+
+async def test_save_config_keeps_saved_token_when_field_omitted(configured, httpx_mock, monkeypatch):
+    """Re-validating without touching the masked token field must not wipe it."""
+    saved = {}
+    monkeypatch.setattr(
+        "app.core.config.save_llm_provider_config",
+        lambda provider_id, cfg: saved.update({provider_id: cfg}) or True,
+    )
+    httpx_mock.add_response(url=f"{HOST}/v1/models", json={"data": []})
+
+    # The frontend omits api_key when only e.g. the SSL checkbox changed.
+    ok, _ = await make_service().save_config(host=HOST, skip_ssl_verify=True)
+    assert ok is True
+    assert saved["lm_studio"].api_key == "lm-test-token"
+    assert saved["lm_studio"].skip_ssl_verify is True
+
+
+async def test_save_config_clears_token_on_explicit_empty(configured, httpx_mock, monkeypatch):
+    saved = {}
+    monkeypatch.setattr(
+        "app.core.config.save_llm_provider_config",
+        lambda provider_id, cfg: saved.update({provider_id: cfg}) or True,
+    )
+    httpx_mock.add_response(url=f"{HOST}/v1/models", json={"data": []})
+
+    ok, _ = await make_service().save_config(host=HOST, api_key="")
+    assert ok is True
+    assert saved["lm_studio"].api_key == ""
+
+
+async def test_skip_ssl_verify_disables_httpx_verification(configured, httpx_mock, monkeypatch):
+    configured.llm.lm_studio.skip_ssl_verify = True
+    httpx_mock.add_response(url=f"{HOST}/api/v0/models", json={"data": []})
+
+    seen = {}
+    original_init = httpx.AsyncClient.__init__
+
+    def spy_init(self, *args, **kwargs):
+        seen["verify"] = kwargs.get("verify", True)
+        return original_init(self, *args, **kwargs)
+
+    monkeypatch.setattr(httpx.AsyncClient, "__init__", spy_init)
+
+    await make_service().get_available_models()
+    assert seen["verify"] is False

--- a/backend/tests/llm_providers/test_ollama_service.py
+++ b/backend/tests/llm_providers/test_ollama_service.py
@@ -1,0 +1,72 @@
+"""Tests for the Ollama provider's connection configuration.
+
+Focused on host normalization and the skip-SSL-verification option, which is
+forwarded to the underlying httpx client for self-signed certificate support.
+"""
+
+import pytest
+
+from app.core import config as C
+from app.services.llm_providers.ollama_service import OllamaService
+
+HOST = "https://ollama.test:11434"
+
+
+@pytest.fixture(autouse=True)
+def isolated_config(monkeypatch):
+    """Use an isolated default config for tests."""
+    app_cfg = C.AppConfig()
+    monkeypatch.setattr(C, "_app_config", app_cfg)
+    return app_cfg
+
+
+def make_service():
+    return OllamaService(lambda *a, **k: None)
+
+
+def test_host_normalization():
+    svc = make_service()
+    assert svc._get_host({"host": "localhost:11434"}) == "http://localhost:11434"
+    assert svc._get_host({"host": HOST}) == HOST
+    assert svc._get_host({"host": ""}) is None
+
+
+def test_skip_ssl_verify_coercion(isolated_config):
+    svc = make_service()
+    assert svc._get_skip_ssl_verify({"skip_ssl_verify": True}) is True
+    assert svc._get_skip_ssl_verify({"skip_ssl_verify": "false"}) is False
+    # Falls back to the saved configuration when not in the passed config.
+    isolated_config.llm.ollama.skip_ssl_verify = True
+    assert svc._get_skip_ssl_verify({}) is True
+
+
+def test_create_client_forwards_verify(monkeypatch):
+    seen = {}
+
+    class FakeClient:
+        def __init__(self, host=None, **kwargs):
+            seen["host"] = host
+            seen["verify"] = kwargs.get("verify")
+
+    monkeypatch.setattr("app.services.llm_providers.ollama_service.ollama.AsyncClient", FakeClient)
+
+    make_service()._create_client(HOST, skip_ssl_verify=True)
+    assert seen == {"host": HOST, "verify": False}
+
+    make_service()._create_client(HOST, skip_ssl_verify=False)
+    assert seen == {"host": HOST, "verify": True}
+
+
+def test_create_client_uses_saved_skip_ssl(isolated_config, monkeypatch):
+    isolated_config.llm.ollama.skip_ssl_verify = True
+
+    seen = {}
+
+    class FakeClient:
+        def __init__(self, host=None, **kwargs):
+            seen["verify"] = kwargs.get("verify")
+
+    monkeypatch.setattr("app.services.llm_providers.ollama_service.ollama.AsyncClient", FakeClient)
+
+    make_service()._create_client(HOST)
+    assert seen["verify"] is False

--- a/backend/tests/llm_providers/test_openai_compatible_service.py
+++ b/backend/tests/llm_providers/test_openai_compatible_service.py
@@ -1,15 +1,19 @@
 """Tests for the generic OpenAI-compatible provider.
 
 Exercises the HTTP surface (model discovery, validation, and the streaming
-chat-completions call) against a mocked endpoint, including the fallback that
-retries without ``response_format`` when a backend rejects it.
+chat-completions call) against a mocked endpoint, including the fallback chain
+that retries with progressively simpler ``response_format`` values when a
+backend rejects one (HTTP 400) or accepts it but produces an unparseable shape.
 """
 
+import asyncio
 import json
 
+import httpx
 import pytest
 
 from app.core import config as C
+from app.services.llm_providers import openai_compatible_service
 from app.services.llm_providers.openai_compatible_service import OpenAICompatibleService
 
 BASE_URL = "http://litellm.test/v1"
@@ -84,18 +88,23 @@ async def test_process_chapter_titles_happy_path(configured, httpx_mock):
     result = await make_service().process_chapter_titles(["chapter one", "noise"], "gpt-4o-mini")
     assert result == ["Chapter 1", None]
 
-    request = httpx_mock.get_request()
-    assert json.loads(request.content)["response_format"] == {"type": "json_object"}
+    # The first attempt requests strict structured output, and the input is
+    # wrapped in the same {"chapters": [...]} shape the prompt describes.
+    payload = json.loads(httpx_mock.get_request().content)
+    assert payload["response_format"]["type"] == "json_schema"
+    user_content = json.loads(payload["messages"][1]["content"])
+    assert user_content == {"chapters": [{"id": 0, "title": "chapter one"}, {"id": 1, "title": "noise"}]}
 
 
-async def test_process_chapter_titles_falls_back_without_response_format(configured, httpx_mock):
-    # First attempt: backend rejects response_format.
-    httpx_mock.add_response(
-        url=f"{BASE_URL}/chat/completions",
-        status_code=400,
-        json={"error": {"message": "response_format is not supported by this model"}},
-    )
-    # Second attempt: succeeds without it.
+async def test_process_chapter_titles_falls_back_through_format_chain(configured, httpx_mock):
+    # First two attempts: backend rejects the schema, then json_object.
+    for message in ("json_schema is not supported", "response_format is not supported by this model"):
+        httpx_mock.add_response(
+            url=f"{BASE_URL}/chat/completions",
+            status_code=400,
+            json={"error": {"message": message}},
+        )
+    # Third attempt: succeeds with no response_format at all.
     obj = {"chapters": [{"id": 0, "title": "Chapter 1"}]}
     httpx_mock.add_response(url=f"{BASE_URL}/chat/completions", content=sse(obj))
 
@@ -103,9 +112,26 @@ async def test_process_chapter_titles_falls_back_without_response_format(configu
     assert result == ["Chapter 1"]
 
     requests = httpx_mock.get_requests()
-    assert len(requests) == 2
-    assert "response_format" in json.loads(requests[0].content)
-    assert "response_format" not in json.loads(requests[1].content)
+    assert len(requests) == 3
+    assert json.loads(requests[0].content)["response_format"]["type"] == "json_schema"
+    assert json.loads(requests[1].content)["response_format"] == {"type": "json_object"}
+    assert "response_format" not in json.loads(requests[2].content)
+
+
+async def test_process_chapter_titles_retries_on_unparseable_shape(configured, httpx_mock):
+    # A backend can accept the response_format yet return the wrong shape —
+    # e.g. Ollama's json_object grammar ends generation after a single object.
+    # The provider must fall back to the next attempt, not hard-fail.
+    httpx_mock.add_response(
+        url=f"{BASE_URL}/chat/completions",
+        content=sse({"id": 0, "title": "Opening Credits"}),
+    )
+    obj = {"chapters": [{"id": 0, "title": "Opening Credits"}]}
+    httpx_mock.add_response(url=f"{BASE_URL}/chat/completions", content=sse(obj))
+
+    result = await make_service().process_chapter_titles(["opening credits"], "llama3.1")
+    assert result == ["Opening Credits"]
+    assert len(httpx_mock.get_requests()) == 2
 
 
 async def test_process_chapter_titles_strips_markdown_fences(configured, httpx_mock):
@@ -121,3 +147,51 @@ async def test_process_chapter_titles_strips_markdown_fences(configured, httpx_m
 
 async def test_process_chapter_titles_empty_input():
     assert await make_service().process_chapter_titles([], "gpt-4o-mini") == []
+
+
+@pytest.mark.parametrize("reasoning_field", ["reasoning_content", "reasoning"])
+async def test_process_chapter_titles_reports_thinking(configured, httpx_mock, reasoning_field):
+    obj = {"chapters": [{"id": 0, "title": "Chapter 1"}]}
+    events = [
+        {"choices": [{"delta": {reasoning_field: "hmm, let me think"}}]},
+        {"choices": [{"delta": {"content": json.dumps(obj)}}]},
+    ]
+    body = "".join("data: " + json.dumps(e) + "\n\n" for e in events) + "data: [DONE]\n\n"
+    httpx_mock.add_response(url=f"{BASE_URL}/chat/completions", content=body.encode())
+
+    messages = []
+    svc = OpenAICompatibleService(lambda step, pct, msg, details: messages.append(msg))
+    result = await svc.process_chapter_titles(["chapter one"], "deepseek-r1")
+
+    # Reasoning deltas surface as a status update and stay out of the parsed content.
+    assert result == ["Chapter 1"]
+    assert "Thinking…" in messages
+
+
+async def test_first_token_watchdog_notifies_when_stream_is_slow(monkeypatch):
+    monkeypatch.setattr(openai_compatible_service, "FIRST_TOKEN_WATCHDOG_SECONDS", 0.0)
+
+    messages = []
+    svc = OpenAICompatibleService(lambda step, pct, msg, details: messages.append(msg))
+    task = svc._start_first_token_watchdog()
+    await asyncio.sleep(0.05)
+
+    assert task.done()
+    assert any("loading the model" in m for m in messages)
+
+
+async def test_skip_ssl_verify_disables_httpx_verification(configured, httpx_mock, monkeypatch):
+    configured.llm.openai_compatible.skip_ssl_verify = True
+    httpx_mock.add_response(url=f"{BASE_URL}/models", json={"data": []})
+
+    seen = {}
+    original_init = httpx.AsyncClient.__init__
+
+    def spy_init(self, *args, **kwargs):
+        seen["verify"] = kwargs.get("verify", True)
+        return original_init(self, *args, **kwargs)
+
+    monkeypatch.setattr(httpx.AsyncClient, "__init__", spy_init)
+
+    await make_service().get_available_models()
+    assert seen["verify"] is False

--- a/backend/tests/llm_providers/test_openrouter_service.py
+++ b/backend/tests/llm_providers/test_openrouter_service.py
@@ -1,0 +1,103 @@
+"""Tests for the OpenRouter provider's streaming chat-completions call.
+
+Focused on the response-format fallback chain: strict ``json_schema`` first,
+then ``json_object``, then no ``response_format`` — advancing on both HTTP 400
+rejections and accepted-but-unparseable responses.
+"""
+
+import json
+
+import pytest
+
+from app.core import config as C
+from app.services.llm_providers.openrouter_service import OpenRouterService
+
+CHAT_URL = "https://openrouter.ai/api/v1/chat/completions"
+
+
+@pytest.fixture(autouse=True)
+def isolated_config(monkeypatch):
+    """Use an isolated default config for tests."""
+    app_cfg = C.AppConfig()
+    monkeypatch.setattr(C, "_app_config", app_cfg)
+    return app_cfg
+
+
+@pytest.fixture
+def configured(isolated_config):
+    """Install an API key so the provider gets past its config check."""
+    isolated_config.llm.openrouter.api_key = "sk-or-test"
+    return isolated_config
+
+
+def make_service():
+    return OpenRouterService(lambda *a, **k: None)
+
+
+def sse(obj) -> bytes:
+    """Encode a chat-completions object as a minimal SSE stream."""
+    delta = {"choices": [{"delta": {"content": json.dumps(obj)}}]}
+    return ("data: " + json.dumps(delta) + "\n\n" + "data: [DONE]\n\n").encode()
+
+
+async def test_process_chapter_titles_happy_path(configured, httpx_mock):
+    obj = {"chapters": [{"id": 0, "title": "Chapter 1"}, {"id": 1, "title": None}]}
+    httpx_mock.add_response(url=CHAT_URL, content=sse(obj))
+
+    result = await make_service().process_chapter_titles(["chapter one", "noise"], "openai/gpt-4o-mini")
+    assert result == ["Chapter 1", None]
+
+    # The first attempt requests strict structured output, and the input is
+    # wrapped in the same {"chapters": [...]} shape the prompt describes.
+    payload = json.loads(httpx_mock.get_request().content)
+    assert payload["response_format"]["type"] == "json_schema"
+    user_content = json.loads(payload["messages"][1]["content"])
+    assert user_content == {"chapters": [{"id": 0, "title": "chapter one"}, {"id": 1, "title": "noise"}]}
+
+
+async def test_process_chapter_titles_falls_back_through_format_chain(configured, httpx_mock):
+    # First two attempts: backend rejects the schema, then json_object.
+    for message in ("json_schema is not supported", "response_format is not supported by this model"):
+        httpx_mock.add_response(
+            url=CHAT_URL,
+            status_code=400,
+            json={"error": {"message": message}},
+        )
+    # Third attempt: succeeds with no response_format at all.
+    obj = {"chapters": [{"id": 0, "title": "Chapter 1"}]}
+    httpx_mock.add_response(url=CHAT_URL, content=sse(obj))
+
+    result = await make_service().process_chapter_titles(["chapter one"], "some/model")
+    assert result == ["Chapter 1"]
+
+    requests = httpx_mock.get_requests()
+    assert len(requests) == 3
+    assert json.loads(requests[0].content)["response_format"]["type"] == "json_schema"
+    assert json.loads(requests[1].content)["response_format"] == {"type": "json_object"}
+    assert "response_format" not in json.loads(requests[2].content)
+
+
+async def test_process_chapter_titles_retries_on_unparseable_shape(configured, httpx_mock):
+    # A model can accept the response_format yet return the wrong shape; the
+    # provider must fall back to the next attempt, not hard-fail.
+    httpx_mock.add_response(url=CHAT_URL, content=sse({"id": 0, "title": "Opening Credits"}))
+    obj = {"chapters": [{"id": 0, "title": "Opening Credits"}]}
+    httpx_mock.add_response(url=CHAT_URL, content=sse(obj))
+
+    result = await make_service().process_chapter_titles(["opening credits"], "some/model")
+    assert result == ["Opening Credits"]
+    assert len(httpx_mock.get_requests()) == 2
+
+
+async def test_thinking_models_get_reasoning_budget(configured, httpx_mock):
+    obj = {"chapters": [{"id": 0, "title": "Chapter 1"}]}
+    httpx_mock.add_response(url=CHAT_URL, content=sse(obj))
+
+    await make_service().process_chapter_titles(["chapter one"], "some/model-thinking")
+
+    payload = json.loads(httpx_mock.get_request().content)
+    assert payload["reasoning"] == {"max_tokens": 1024}
+
+
+async def test_process_chapter_titles_empty_input():
+    assert await make_service().process_chapter_titles([], "openai/gpt-4o-mini") == []

--- a/backend/tests/llm_providers/test_registry.py
+++ b/backend/tests/llm_providers/test_registry.py
@@ -1,0 +1,49 @@
+"""Tests for the provider registry's model list cache.
+
+Self-hosted providers (Ollama, LM Studio, OpenAI-compatible) opt out of
+caching via ``CACHE_MODELS`` so models the user adds or removes show up
+immediately; cloud providers keep the cache since their catalogs change
+rarely and can be slow to fetch.
+"""
+
+from app.services.llm_providers.base import ModelInfo
+from app.services.llm_providers.lm_studio_service import LMStudioService
+from app.services.llm_providers.ollama_service import OllamaService
+from app.services.llm_providers.openai_compatible_service import OpenAICompatibleService
+from app.services.llm_providers.registry import ProviderRegistry
+
+
+def test_self_hosted_providers_opt_out_of_model_cache():
+    assert OllamaService.CACHE_MODELS is False
+    assert LMStudioService.CACHE_MODELS is False
+    assert OpenAICompatibleService.CACHE_MODELS is False
+
+
+async def test_get_provider_models_skips_cache_for_self_hosted(monkeypatch):
+    registry = ProviderRegistry()
+    calls = {"ollama": 0, "openai": 0}
+
+    async def fake_ollama_models(self):
+        calls["ollama"] += 1
+        return [ModelInfo(id="local-model", name="local-model")]
+
+    async def fake_openai_models(self):
+        calls["openai"] += 1
+        return [ModelInfo(id="gpt-test", name="gpt-test")]
+
+    monkeypatch.setattr(
+        "app.services.llm_providers.ollama_service.OllamaService.get_available_models", fake_ollama_models
+    )
+    monkeypatch.setattr(
+        "app.services.llm_providers.openai_service.OpenAIService.get_available_models", fake_openai_models
+    )
+
+    # Self-hosted: every call fetches fresh.
+    await registry.get_provider_models("ollama", host="http://localhost:11434")
+    await registry.get_provider_models("ollama", host="http://localhost:11434")
+    assert calls["ollama"] == 2
+
+    # Cloud provider: second call is served from the cache.
+    await registry.get_provider_models("openai", api_key="sk-test")
+    await registry.get_provider_models("openai", api_key="sk-test")
+    assert calls["openai"] == 1

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -33,7 +33,6 @@ dependencies = [
     { name = "google-genai", extra = ["aiohttp"] },
     { name = "httpx" },
     { name = "langcodes", extra = ["data"] },
-    { name = "lmstudio" },
     { name = "mlx-whisper", marker = "sys_platform == 'darwin'" },
     { name = "numpy" },
     { name = "ollama" },
@@ -67,7 +66,6 @@ requires-dist = [
     { name = "google-genai", extras = ["aiohttp"], specifier = ">=1.65.0" },
     { name = "httpx", specifier = ">=0.25.2" },
     { name = "langcodes", extras = ["data"], specifier = ">=3.4.0" },
-    { name = "lmstudio", specifier = "==1.4.1" },
     { name = "mlx-whisper", marker = "sys_platform == 'darwin'", specifier = ">=0.4.3" },
     { name = "numpy", specifier = ">=1.24.4" },
     { name = "ollama", specifier = ">=0.5.1" },
@@ -732,21 +730,6 @@ wheels = [
 ]
 
 [[package]]
-name = "httpx-ws"
-version = "0.7.2"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "anyio" },
-    { name = "httpcore" },
-    { name = "httpx" },
-    { name = "wsproto" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/56/ba/e310ccdb8f18a2b894bfacd085ef390cf6cc70bb10ff9f109d58d94f6b47/httpx_ws-0.7.2.tar.gz", hash = "sha256:93edea6c8fc313464fc287bff7d2ad20e6196b7754c76f946f73b4af79886d4e", size = 24513, upload-time = "2025-03-28T13:20:03.039Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/03/3d/2113a5c7af9a13663fa026882d0302ed4142960388536f885dacd6be7038/httpx_ws-0.7.2-py3-none-any.whl", hash = "sha256:dd7bf9dbaa96dcd5cef1af3a7e1130cfac068bebecce25a74145022f5a8427a3", size = 14424, upload-time = "2025-03-28T13:20:04.238Z" },
-]
-
-[[package]]
 name = "huggingface-hub"
 version = "0.34.4"
 source = { registry = "https://pypi.org/simple" }
@@ -930,22 +913,6 @@ wheels = [
 ]
 
 [[package]]
-name = "lmstudio"
-version = "1.4.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "anyio" },
-    { name = "httpx" },
-    { name = "httpx-ws" },
-    { name = "msgspec" },
-    { name = "typing-extensions" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/f6/69/dc4303a9b17e9c5d1c697d8a0b9825472efde56a37e57ba776eaaba7186f/lmstudio-1.4.1.tar.gz", hash = "sha256:533a028006711f43aa8118de3cb9a3225901ab3da6e8a8141bb4bbe15438ccc0", size = 168436, upload-time = "2025-06-30T18:07:04.732Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/a1/c6/3d4156b0d57a5dcb909b0ab48e8c112ca67d80f731e1f54003e154379dcd/lmstudio-1.4.1-py3-none-any.whl", hash = "sha256:aefc6775d9fb5929403d2d96ec4536be869a96e89e032e7bcceb9de73f7c08b2", size = 106358, upload-time = "2025-06-30T18:07:03.487Z" },
-]
-
-[[package]]
 name = "marisa-trie"
 version = "1.4.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1087,35 +1054,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/ab/65/7d1de38c8a22cf8b1551469159d4b6cf49be2126adc2482de50976084d78/msgpack-1.1.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:33be9ab121df9b6b461ff91baac6f2731f83d9b27ed948c5b9d1978ae28bf157", size = 79172, upload-time = "2025-06-13T06:52:05.246Z" },
     { url = "https://files.pythonhosted.org/packages/a1/38/561f01cf3577430b59b340b51329803d3a5bf6a45864a55f4ef308ac11e3/msgpack-1.1.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:3765afa6bd4832fc11c3749be4ba4b69a0e8d7b728f78e68120a157a4c5d41f0", size = 81677, upload-time = "2025-06-13T06:52:16.64Z" },
     { url = "https://files.pythonhosted.org/packages/09/48/54a89579ea36b6ae0ee001cba8c61f776451fad3c9306cd80f5b5c55be87/msgpack-1.1.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:8ddb2bcfd1a8b9e431c8d6f4f7db0773084e107730ecf3472f1dfe9ad583f3d9", size = 78603, upload-time = "2025-06-13T06:52:17.843Z" },
-]
-
-[[package]]
-name = "msgspec"
-version = "0.19.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/cf/9b/95d8ce458462b8b71b8a70fa94563b2498b89933689f3a7b8911edfae3d7/msgspec-0.19.0.tar.gz", hash = "sha256:604037e7cd475345848116e89c553aa9a233259733ab51986ac924ab1b976f8e", size = 216934, upload-time = "2024-12-27T17:40:28.597Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/24/d4/2ec2567ac30dab072cce3e91fb17803c52f0a37aab6b0c24375d2b20a581/msgspec-0.19.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:aa77046904db764b0462036bc63ef71f02b75b8f72e9c9dd4c447d6da1ed8f8e", size = 187939, upload-time = "2024-12-27T17:39:32.347Z" },
-    { url = "https://files.pythonhosted.org/packages/2b/c0/18226e4328897f4f19875cb62bb9259fe47e901eade9d9376ab5f251a929/msgspec-0.19.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:047cfa8675eb3bad68722cfe95c60e7afabf84d1bd8938979dd2b92e9e4a9551", size = 182202, upload-time = "2024-12-27T17:39:33.633Z" },
-    { url = "https://files.pythonhosted.org/packages/81/25/3a4b24d468203d8af90d1d351b77ea3cffb96b29492855cf83078f16bfe4/msgspec-0.19.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e78f46ff39a427e10b4a61614a2777ad69559cc8d603a7c05681f5a595ea98f7", size = 209029, upload-time = "2024-12-27T17:39:35.023Z" },
-    { url = "https://files.pythonhosted.org/packages/85/2e/db7e189b57901955239f7689b5dcd6ae9458637a9c66747326726c650523/msgspec-0.19.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6c7adf191e4bd3be0e9231c3b6dc20cf1199ada2af523885efc2ed218eafd011", size = 210682, upload-time = "2024-12-27T17:39:36.384Z" },
-    { url = "https://files.pythonhosted.org/packages/03/97/7c8895c9074a97052d7e4a1cc1230b7b6e2ca2486714eb12c3f08bb9d284/msgspec-0.19.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:f04cad4385e20be7c7176bb8ae3dca54a08e9756cfc97bcdb4f18560c3042063", size = 214003, upload-time = "2024-12-27T17:39:39.097Z" },
-    { url = "https://files.pythonhosted.org/packages/61/61/e892997bcaa289559b4d5869f066a8021b79f4bf8e955f831b095f47a4cd/msgspec-0.19.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:45c8fb410670b3b7eb884d44a75589377c341ec1392b778311acdbfa55187716", size = 216833, upload-time = "2024-12-27T17:39:41.203Z" },
-    { url = "https://files.pythonhosted.org/packages/ce/3d/71b2dffd3a1c743ffe13296ff701ee503feaebc3f04d0e75613b6563c374/msgspec-0.19.0-cp311-cp311-win_amd64.whl", hash = "sha256:70eaef4934b87193a27d802534dc466778ad8d536e296ae2f9334e182ac27b6c", size = 186184, upload-time = "2024-12-27T17:39:43.702Z" },
-    { url = "https://files.pythonhosted.org/packages/b2/5f/a70c24f075e3e7af2fae5414c7048b0e11389685b7f717bb55ba282a34a7/msgspec-0.19.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:f98bd8962ad549c27d63845b50af3f53ec468b6318400c9f1adfe8b092d7b62f", size = 190485, upload-time = "2024-12-27T17:39:44.974Z" },
-    { url = "https://files.pythonhosted.org/packages/89/b0/1b9763938cfae12acf14b682fcf05c92855974d921a5a985ecc197d1c672/msgspec-0.19.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:43bbb237feab761b815ed9df43b266114203f53596f9b6e6f00ebd79d178cdf2", size = 183910, upload-time = "2024-12-27T17:39:46.401Z" },
-    { url = "https://files.pythonhosted.org/packages/87/81/0c8c93f0b92c97e326b279795f9c5b956c5a97af28ca0fbb9fd86c83737a/msgspec-0.19.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4cfc033c02c3e0aec52b71710d7f84cb3ca5eb407ab2ad23d75631153fdb1f12", size = 210633, upload-time = "2024-12-27T17:39:49.099Z" },
-    { url = "https://files.pythonhosted.org/packages/d0/ef/c5422ce8af73928d194a6606f8ae36e93a52fd5e8df5abd366903a5ca8da/msgspec-0.19.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d911c442571605e17658ca2b416fd8579c5050ac9adc5e00c2cb3126c97f73bc", size = 213594, upload-time = "2024-12-27T17:39:51.204Z" },
-    { url = "https://files.pythonhosted.org/packages/19/2b/4137bc2ed45660444842d042be2cf5b18aa06efd2cda107cff18253b9653/msgspec-0.19.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:757b501fa57e24896cf40a831442b19a864f56d253679f34f260dcb002524a6c", size = 214053, upload-time = "2024-12-27T17:39:52.866Z" },
-    { url = "https://files.pythonhosted.org/packages/9d/e6/8ad51bdc806aac1dc501e8fe43f759f9ed7284043d722b53323ea421c360/msgspec-0.19.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:5f0f65f29b45e2816d8bded36e6b837a4bf5fb60ec4bc3c625fa2c6da4124537", size = 219081, upload-time = "2024-12-27T17:39:55.142Z" },
-    { url = "https://files.pythonhosted.org/packages/b1/ef/27dd35a7049c9a4f4211c6cd6a8c9db0a50647546f003a5867827ec45391/msgspec-0.19.0-cp312-cp312-win_amd64.whl", hash = "sha256:067f0de1c33cfa0b6a8206562efdf6be5985b988b53dd244a8e06f993f27c8c0", size = 187467, upload-time = "2024-12-27T17:39:56.531Z" },
-    { url = "https://files.pythonhosted.org/packages/3c/cb/2842c312bbe618d8fefc8b9cedce37f773cdc8fa453306546dba2c21fd98/msgspec-0.19.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:f12d30dd6266557aaaf0aa0f9580a9a8fbeadfa83699c487713e355ec5f0bd86", size = 190498, upload-time = "2024-12-27T17:40:00.427Z" },
-    { url = "https://files.pythonhosted.org/packages/58/95/c40b01b93465e1a5f3b6c7d91b10fb574818163740cc3acbe722d1e0e7e4/msgspec-0.19.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:82b2c42c1b9ebc89e822e7e13bbe9d17ede0c23c187469fdd9505afd5a481314", size = 183950, upload-time = "2024-12-27T17:40:04.219Z" },
-    { url = "https://files.pythonhosted.org/packages/e8/f0/5b764e066ce9aba4b70d1db8b087ea66098c7c27d59b9dd8a3532774d48f/msgspec-0.19.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:19746b50be214a54239aab822964f2ac81e38b0055cca94808359d779338c10e", size = 210647, upload-time = "2024-12-27T17:40:05.606Z" },
-    { url = "https://files.pythonhosted.org/packages/9d/87/bc14f49bc95c4cb0dd0a8c56028a67c014ee7e6818ccdce74a4862af259b/msgspec-0.19.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:60ef4bdb0ec8e4ad62e5a1f95230c08efb1f64f32e6e8dd2ced685bcc73858b5", size = 213563, upload-time = "2024-12-27T17:40:10.516Z" },
-    { url = "https://files.pythonhosted.org/packages/53/2f/2b1c2b056894fbaa975f68f81e3014bb447516a8b010f1bed3fb0e016ed7/msgspec-0.19.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:ac7f7c377c122b649f7545810c6cd1b47586e3aa3059126ce3516ac7ccc6a6a9", size = 213996, upload-time = "2024-12-27T17:40:12.244Z" },
-    { url = "https://files.pythonhosted.org/packages/aa/5a/4cd408d90d1417e8d2ce6a22b98a6853c1b4d7cb7669153e4424d60087f6/msgspec-0.19.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:a5bc1472223a643f5ffb5bf46ccdede7f9795078194f14edd69e3aab7020d327", size = 219087, upload-time = "2024-12-27T17:40:14.881Z" },
-    { url = "https://files.pythonhosted.org/packages/23/d8/f15b40611c2d5753d1abb0ca0da0c75348daf1252220e5dda2867bd81062/msgspec-0.19.0-cp313-cp313-win_amd64.whl", hash = "sha256:317050bc0f7739cb30d257ff09152ca309bf5a369854bbf1e57dffc310c1f20f", size = 187432, upload-time = "2024-12-27T17:40:16.256Z" },
 ]
 
 [[package]]
@@ -2347,18 +2285,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/86/eb/20b6cdf273913d0ad05a6a14aed4b9a85591c18a987a3d47f20fa13dcc47/websockets-15.0.1-cp313-cp313-win32.whl", hash = "sha256:ba9e56e8ceeeedb2e080147ba85ffcd5cd0711b89576b83784d8605a7df455fa", size = 176393, upload-time = "2025-03-05T20:02:53.814Z" },
     { url = "https://files.pythonhosted.org/packages/1b/6c/c65773d6cab416a64d191d6ee8a8b1c68a09970ea6909d16965d26bfed1e/websockets-15.0.1-cp313-cp313-win_amd64.whl", hash = "sha256:e09473f095a819042ecb2ab9465aee615bd9c2028e4ef7d933600a8401c79561", size = 176837, upload-time = "2025-03-05T20:02:55.237Z" },
     { url = "https://files.pythonhosted.org/packages/fa/a8/5b41e0da817d64113292ab1f8247140aac61cbf6cfd085d6a0fa77f4984f/websockets-15.0.1-py3-none-any.whl", hash = "sha256:f7a866fbc1e97b5c617ee4116daaa09b722101d4a3c170c787450ba409f9736f", size = 169743, upload-time = "2025-03-05T20:03:39.41Z" },
-]
-
-[[package]]
-name = "wsproto"
-version = "1.2.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "h11" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/c9/4a/44d3c295350d776427904d73c189e10aeae66d7f555bb2feee16d1e4ba5a/wsproto-1.2.0.tar.gz", hash = "sha256:ad565f26ecb92588a3e43bc3d96164de84cd9902482b130d0ddbaa9664a85065", size = 53425, upload-time = "2022-08-23T19:58:21.447Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/78/58/e860788190eba3bcce367f74d29c4675466ce8dddfba85f7827588416f01/wsproto-1.2.0-py3-none-any.whl", hash = "sha256:b9acddd652b585d75b20477888c56642fdade28bdfd3579aa24a4d2c037dd736", size = 24226, upload-time = "2022-08-23T19:58:19.96Z" },
 ]
 
 [[package]]

--- a/docs/getting-started/setup-llm-providers.md
+++ b/docs/getting-started/setup-llm-providers.md
@@ -22,8 +22,8 @@ See the relevant provider card below for setup steps.
 | [Google Gemini](#gemini-google) | Free/Paid | API key | Free tier has limited model selection and [rate limits](https://ai.google.dev/gemini-api/docs/rate-limits){:target="_blank"}. <br><br> Prefer `Flash` models for most tasks, `Lite` models for simple cleanup, and `Pro` models for complex cleanup. |
 | [OpenRouter](#openrouter) | Free/Paid | API key | Free tier has limited [model selection](https://openrouter.ai/collections/free-models){:target="_blank"}, a limit of [50 requests/day](https://openrouter.ai/pricing){:target="_blank"}, and spotty service. Small models do not work well; try to use 16B+ parameter models. |
 | [GitHub Copilot](#github-copilot) | Free/Paid | Personal access token | Free tier has limited [model selection](https://docs.github.com/en/copilot/reference/ai-models/supported-models#supported-ai-models-per-copilot-plan){:target="_blank"} and a limited monthly allowance of [GitHub AI credits](https://docs.github.com/en/copilot/concepts/billing/usage-based-billing-for-individuals){:target="_blank"}, consumed based on token usage. |
-| [Ollama](#ollama) | Free (self-hosted) | Host URL | Local, private, unlimited. Small models do not work well; try to use 16B+ parameter models. |
-| [LM Studio](#lm-studio) | Free (self-hosted) | Host URL | Local, private, unlimited. Small models do not work well; try to use 16B+ parameter models. |
+| [Ollama](#ollama) | Free (self-hosted) | Server URL | Local, private, unlimited. Small models do not work well; try to use 16B+ parameter models. |
+| [LM Studio](#lm-studio) | Free (self-hosted) | Server URL + optional API token | Local, private, unlimited. Small models do not work well; try to use 16B+ parameter models. |
 | [OpenAI-Compatible](#openai-compatible) | Varies | Base URL + optional API key | Connect to any OpenAI-compatible endpoint (e.g. LiteLLM, vLLM). Available models and cost depend on the endpoint you point it at. |
 
 ---
@@ -93,7 +93,9 @@ See the relevant provider card below for setup steps.
 ??? example "Ollama"
     Install [Ollama](https://ollama.com/download){:target="_blank"} on your machine and pull a model (e.g. `ollama pull qwen3.6:27b`). Ollama runs a local server at `http://localhost:11434` by default.
 
-    In Achew, go to **Settings -> LLM Setup** and enable the Ollama card. Enter the Ollama host URL into the input field, then click **Validate**. If Achew is running in Docker and Ollama is on the same host, use `http://host.docker.internal:11434` on macOS/Windows, or your LAN IP on Linux. Once validated, you'll be able to use Ollama as a provider for AI Cleanup in the chapter editor.
+    In Achew, go to **Settings -> LLM Setup** and enable the Ollama card. Enter the **Server URL** into the input field (with or without `http://`/`https://` — plain host:port defaults to `http://`), then click **Validate**. If Achew is running in Docker and Ollama is on the same host, use `http://host.docker.internal:11434` on macOS/Windows, or your LAN IP on Linux. Once validated, you'll be able to use Ollama as a provider for AI Cleanup in the chapter editor.
+
+    If you expose Ollama over HTTPS with a self-signed certificate, check **Skip SSL certificate verification**. Only enable this for servers you trust.
 
     !!! tip "Model size matters"
         Small models rarely produce usable results. Try to use 16B+ parameter models if possible.
@@ -102,7 +104,9 @@ See the relevant provider card below for setup steps.
 ??? example "LM Studio"
     Install [LM Studio](https://lmstudio.ai/){:target="_blank"}, download a model from the **Discover** tab, then start the local server from the **Developer** tab. LM Studio listens on `http://localhost:1234` by default.
 
-    In Achew, go to **Settings -> LLM Setup** and enable the LM Studio card. Enter the host URL into the input field, then click **Validate**. Once validated, you can use LM Studio as a provider for AI Cleanup in the chapter editor.
+    In Achew, go to **Settings -> LLM Setup** and enable the LM Studio card. Enter the **Server URL** into the input field (with or without `http://`/`https://` — plain host:port defaults to `http://`), then click **Validate**. Once validated, you can use LM Studio as a provider for AI Cleanup in the chapter editor.
+
+    If you've enabled authentication on the LM Studio server ([API tokens](https://lmstudio.ai/docs/developer/core/authentication){:target="_blank"}), paste a token into the **API Token** field; otherwise leave it blank. If the server is behind HTTPS with a self-signed certificate, check **Skip SSL certificate verification**. Only enable this for servers you trust.
 
     !!! tip "Model size matters"
         Small models rarely produce usable results. Try to use 16B+ parameter models if possible.
@@ -111,7 +115,7 @@ See the relevant provider card below for setup steps.
 ??? example "OpenAI-Compatible"
     This provider connects to any endpoint that implements the OpenAI REST API — for example [LiteLLM](https://docs.litellm.ai/){:target="_blank"}, [vLLM](https://docs.vllm.ai/){:target="_blank"}, or another self-hosted gateway. It lists whatever models the endpoint advertises, so you pick the specific model at cleanup time.
 
-    In Achew, go to **Settings -> LLM Setup** and enable the OpenAI-Compatible card. Enter the **Base URL** of the endpoint's API root — the path that serves `/models` and `/chat/completions`, commonly ending in `/v1` (e.g. `http://litellm.local:4000/v1`). Provide an **API Key** if the endpoint requires one, or leave it blank for keyless gateways. Click **Validate**, and once connected you can use it as a provider for AI Cleanup in the chapter editor.
+    In Achew, go to **Settings -> LLM Setup** and enable the OpenAI-Compatible card. Enter the **Base URL** of the endpoint's API root — the path that serves `/models` and `/chat/completions`, commonly ending in `/v1` (e.g. `http://litellm.local:4000/v1`). Provide an **API Key** if the endpoint requires one, or leave it blank for keyless gateways. If the endpoint uses HTTPS with a self-signed certificate, check **Skip SSL certificate verification** (only for servers you trust). Click **Validate**, and once connected you can use it as a provider for AI Cleanup in the chapter editor.
 
     !!! tip "Docker networking"
         If Achew runs in a container, `localhost` refers to the container itself. Point the Base URL at the host or LAN IP instead (e.g. `http://host.docker.internal:4000/v1` on macOS/Windows).

--- a/frontend/src/components/LLMSetup.svelte
+++ b/frontend/src/components/LLMSetup.svelte
@@ -1,10 +1,12 @@
 <script lang="ts">
   import { onMount } from 'svelte';
   import { llm } from '../utils/api';
+  import { tooltip } from '../actions/tooltip';
   import DocLink from './DocLink.svelte';
   import Icon from './Icon.svelte';
 
   import Check from '@lucide/svelte/icons/check';
+  import CircleQuestionMark from '@lucide/svelte/icons/circle-question-mark';
   import ExternalLink from '@lucide/svelte/icons/external-link';
   import Info from '@lucide/svelte/icons/info';
   import TriangleAlert from '@lucide/svelte/icons/triangle-alert';
@@ -19,16 +21,18 @@
 
   type ProviderInfo = LLMProvider;
 
+  type FieldValue = string | boolean;
+
   let providers = $state<ProviderInfo[]>([]);
-  let providerConfigs = $state<Record<string, Record<string, string>>>({});
-  let originalConfigs = $state<Record<string, Record<string, string>>>({});
+  let providerConfigs = $state<Record<string, Record<string, FieldValue>>>({});
+  let originalConfigs = $state<Record<string, Record<string, FieldValue>>>({});
   let loading = $state(false);
   let validating = $state<Record<string, boolean>>({});
 
   let debounceTimers: Record<string, ReturnType<typeof setTimeout>> = {};
 
   // Auto-validate when provider configs change
-  function handleProviderConfigChange(providerId: string, fieldName: string, value: string) {
+  function handleProviderConfigChange(providerId: string, fieldName: string, value: FieldValue) {
     // Update the config
     providerConfigs[providerId][fieldName] = value;
     providerConfigs = { ...providerConfigs };
@@ -62,8 +66,9 @@
         // Initialize config fields based on setup_fields
         for (const field of provider.setup_fields) {
           // Always start with empty values, don't use placeholder as default
-          providerConfigs[provider.id][field.name] = '';
-          originalConfigs[provider.id][field.name] = '';
+          const emptyValue = field.type === 'checkbox' ? false : '';
+          providerConfigs[provider.id][field.name] = emptyValue;
+          originalConfigs[provider.id][field.name] = emptyValue;
         }
       }
 
@@ -80,11 +85,14 @@
       // Load actual saved configs from backend for each provider
       for (const provider of providers) {
         try {
-          const result = (await llm.getProviderConfig(provider.id)) as { config?: Record<string, string> };
+          const result = (await llm.getProviderConfig(provider.id)) as { config?: Record<string, FieldValue> };
           if (result && result.config) {
             for (const field of provider.setup_fields) {
               const savedValue = result.config[field.name];
-              if (savedValue) {
+              if (field.type === 'checkbox') {
+                providerConfigs[provider.id][field.name] = Boolean(savedValue);
+                originalConfigs[provider.id][field.name] = Boolean(savedValue);
+              } else if (savedValue) {
                 if (field.type === 'password') {
                   // Show placeholder for password fields if configured
                   providerConfigs[provider.id][field.name] = '••••••••••••••••••••••••••••••••••••••••••••••••••••';
@@ -113,14 +121,16 @@
   function saveProviderConfigsToStorage() {
     try {
       // Save non-sensitive configs to localStorage
-      const configsToSave: Record<string, Record<string, string>> = {};
+      const configsToSave: Record<string, Record<string, FieldValue>> = {};
       for (const provider of providers) {
         configsToSave[provider.id] = {};
         for (const field of provider.setup_fields) {
           // Only save non-password fields
           if (field.type !== 'password') {
             const value = providerConfigs[provider.id][field.name];
-            if (value && !value.startsWith('••••')) {
+            if (typeof value === 'boolean') {
+              configsToSave[provider.id][field.name] = value;
+            } else if (value && !value.startsWith('••••')) {
               configsToSave[provider.id][field.name] = value;
             }
           }
@@ -226,14 +236,16 @@
     }
   }
 
-  function getProviderConfigForValidation(providerId: string): Record<string, string> {
-    const config: Record<string, string> = {};
+  function getProviderConfigForValidation(providerId: string): Record<string, FieldValue> {
+    const config: Record<string, FieldValue> = {};
     const provider = providers.find((p) => p.id === providerId);
     if (!provider) return config;
 
     for (const field of provider.setup_fields) {
       const value = providerConfigs[providerId][field.name];
-      if (value && !value.startsWith('••••')) {
+      if (typeof value === 'boolean') {
+        config[field.name] = value;
+      } else if (value && !value.startsWith('••••')) {
         config[field.name] = value;
       } else if (originalConfigs[providerId][field.name] === '***') {
         // Keep existing config - don't send placeholder
@@ -255,7 +267,7 @@
       const originalValue = originalConfigs[providerId][field.name];
 
       // For password fields, if current value is placeholder, no change
-      if (field.type === 'password' && currentValue && currentValue.startsWith('••••')) {
+      if (field.type === 'password' && typeof currentValue === 'string' && currentValue.startsWith('••••')) {
         continue;
       }
 
@@ -445,21 +457,40 @@
             {/if}
 
             <div class="form-group">
-              <input
-                id="{provider.id}-{field.name}"
-                type={field.type === 'password' ? 'password' : 'text'}
-                autocomplete="off"
-                data-1p-ignore
-                data-lpignore="true"
-                data-bwignore
-                data-form-type="other"
-                bind:value={providerConfigs[provider.id][field.name]}
-                placeholder={field.placeholder || field.label}
-                disabled={loading || !provider.is_enabled}
-                required={field.required}
-                oninput={() =>
-                  handleProviderConfigChange(provider.id, field.name, providerConfigs[provider.id][field.name])}
-              />
+              {#if field.type === 'checkbox'}
+                <label class="checkbox-field">
+                  <input
+                    id="{provider.id}-{field.name}"
+                    type="checkbox"
+                    checked={Boolean(providerConfigs[provider.id][field.name])}
+                    disabled={loading || !provider.is_enabled}
+                    onchange={(e) =>
+                      handleProviderConfigChange(provider.id, field.name, (e.target as HTMLInputElement).checked)}
+                  />
+                  <span>{field.label}</span>
+                  {#if field.help_text}
+                    <div class="help-icon" use:tooltip={{ text: field.help_text, delay: 0 }}>
+                      <CircleQuestionMark size="14" />
+                    </div>
+                  {/if}
+                </label>
+              {:else}
+                <input
+                  id="{provider.id}-{field.name}"
+                  type={field.type === 'password' ? 'password' : 'text'}
+                  autocomplete="off"
+                  data-1p-ignore
+                  data-lpignore="true"
+                  data-bwignore
+                  data-form-type="other"
+                  value={String(providerConfigs[provider.id][field.name] ?? '')}
+                  placeholder={field.placeholder || field.label}
+                  disabled={loading || !provider.is_enabled}
+                  required={field.required}
+                  oninput={(e) =>
+                    handleProviderConfigChange(provider.id, field.name, (e.target as HTMLInputElement).value)}
+                />
+              {/if}
             </div>
           {/each}
 
@@ -708,6 +739,7 @@
     display: flex;
     flex-direction: column;
     gap: 0.25rem;
+    margin-top: 1.25rem;
   }
 
   .form-group {
@@ -720,7 +752,6 @@
   .field-hint {
     font-size: 0.75rem;
     color: var(--text-secondary);
-    margin-top: 0.5rem;
     margin-bottom: 0;
     display: flex;
     align-items: center;
@@ -734,6 +765,46 @@
 
   .field-hint a:hover {
     text-decoration: underline;
+  }
+
+  .checkbox-field {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    cursor: pointer;
+    color: var(--text-primary);
+    font-size: 0.9rem;
+    width: fit-content;
+  }
+
+  .checkbox-field input[type='checkbox'] {
+    width: 16px;
+    height: 16px;
+    margin: 0;
+    accent-color: var(--primary-color);
+    cursor: pointer;
+    flex-shrink: 0;
+  }
+
+  .checkbox-field input[type='checkbox']:disabled {
+    cursor: not-allowed;
+  }
+
+  .help-icon {
+    border: none;
+    background: transparent;
+    color: var(--text-secondary);
+    padding: 2px;
+    border-radius: 50%;
+    transition: all 0.2s ease;
+    position: relative;
+    cursor: help;
+    display: flex;
+  }
+
+  .help-icon:hover {
+    color: var(--primary-color);
+    background: var(--bg-tertiary);
   }
 
   .provider-actions {


### PR DESCRIPTION
- Adds option to skip SSL verify for self-hostable providers: Ollama, LM Studio, OpenAI-Compatible
- Adds optional API token for LM studio
- Makes a necessary switch from SDK to API for LM Studio
- Unifies requested response format across providers, w/ fallback chain
- No longer caches model list for self-hostable providers
- Adds attempt to surface thinking/loading hints
- Adds/updates related docs and tests

Closes #112